### PR TITLE
Fix search to copy selection & fix mise tasks on Windows

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,13 +3,14 @@
 #   mise install         Rust ツールチェーンのセットアップ
 #   mise run build       debug ビルド → ルートにコピー
 #   mise run release     release ビルド → ルートにコピー
-#   mise run run         ビルド後、kanata も起動
+#   mise run dev         ビルド後、kanata も起動
 
 [tools]
 rust = "1.93"
 
 [tasks.build]
 description = "Build muhenkan-switch (debug)"
+shell = "bash -c"
 run = """
 cargo build --manifest-path muhenkan-switch/Cargo.toml
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
@@ -19,6 +20,7 @@ echo "[dev] Copied -> ./muhenkan-switch${EXT}"
 
 [tasks.release]
 description = "Build muhenkan-switch (release)"
+shell = "bash -c"
 run = """
 cargo build --release --manifest-path muhenkan-switch/Cargo.toml
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
@@ -26,9 +28,10 @@ cp "muhenkan-switch/target/release/muhenkan-switch${EXT}" "./muhenkan-switch${EX
 echo "[dev] Copied -> ./muhenkan-switch${EXT}"
 """
 
-[tasks.run]
+[tasks.dev]
 description = "Build and start kanata"
 depends = ["build"]
+shell = "bash -c"
 run = """
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
 KANATA="./kanata_cmd_allowed${EXT}"

--- a/muhenkan-switch/src/commands/search.rs
+++ b/muhenkan-switch/src/commands/search.rs
@@ -1,11 +1,16 @@
 use anyhow::Result;
 use arboard::Clipboard;
+use std::process::Command;
 
 use crate::config::{self, Config};
 
 pub fn run(engine: &str, config: &Config) -> Result<()> {
     // 検索エンジンのURLテンプレートを取得
     let url_template = config::get_value(&config.search, engine, "Search engine")?;
+
+    // 選択テキストをクリップボードにコピー（Ctrl+C シミュレート）
+    copy_selection()?;
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
     // クリップボードからテキスト取得
     let mut clipboard = Clipboard::new()?;
@@ -21,5 +26,36 @@ pub fn run(engine: &str, config: &Config) -> Result<()> {
     let url = url_template.replace("{query}", &encoded);
     webbrowser::open(&url)?;
 
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn copy_selection() -> Result<()> {
+    let script = r#"
+        Add-Type -AssemblyName System.Windows.Forms
+        [System.Windows.Forms.SendKeys]::SendWait('^c')
+    "#;
+    Command::new("powershell")
+        .args(["-NoProfile", "-Command", script])
+        .output()?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn copy_selection() -> Result<()> {
+    Command::new("xdotool")
+        .args(["key", "ctrl+c"])
+        .output()?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn copy_selection() -> Result<()> {
+    Command::new("osascript")
+        .args([
+            "-e",
+            r#"tell application "System Events" to keystroke "c" using command down"#,
+        ])
+        .output()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- **検索コマンド修正**: `muhenkan-switch search` 実行時、クリップボード読み取り前に Ctrl+C をシミュレートして選択テキストをコピーするように修正。以前はクリップボードの既存内容で検索されていた。
- **mise タスク修正**: Windows で bash スクリプトが cmd.exe で実行される問題を `shell = "bash -c"` で修正。タスク名 `run` → `dev` にリネーム。

## Test plan
- [x] `mise run build` がエラーなくビルドできること
- [x] `mise run dev` でビルド + kanata 起動ができること
- [x] 無変換+G (Google) で選択テキストが検索されること
- [x] 無変換+Q (ejje), 無変換+R (thesaurus), 無変換+T (translate) も同様に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)