### PR TITLE
Improve Windows install experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scrip
 インストールスクリプトは以下を自動で行います:
 - kanata のダウンロード（GitHub Releases から）
 - ファイルの配置（下記インストール先）
-- PATH の設定（Windows: ユーザー環境変数、Linux/macOS: `~/.local/bin` にシンボリックリンク）
+- PATH の設定（Linux/macOS: `~/.local/bin` にシンボリックリンク）
+- スタートメニューショートカットの作成（Windows）
 - オプション: 自動起動の設定（Windows: スタートアップ、Linux: XDG autostart、macOS: launchd）
 
 | OS | インストール先 |
@@ -101,13 +102,11 @@ irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scrip
 └── config.toml                # muhenkan-switch 設定ファイル
 ```
 
-### 2. ターミナルを再起動
+### 2. 起動
 
-PATH の変更を反映するため、ターミナルを再起動してください。
+スタートメニューから `muhenkan-switch` を起動してください（Windows）。システムトレイに常駐し、kanata を自動管理します。
 
-### 3. 起動
-
-`muhenkan-switch` を起動してください。システムトレイに常駐し、kanata を自動管理します。
+Linux/macOS ではターミナルから `muhenkan-switch` を実行してください。
 
 無変換キーを押しながら H/J/K/L でカーソルが移動すれば成功です。
 
@@ -144,7 +143,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 手動で削除する場合は、以下を削除してください:
 - インストールディレクトリ（上記表を参照）
-- PATH からインストールディレクトリを除去（Windows のみ）
+- スタートメニューショートカット（Windows）/ PATH のシンボリックリンク（Linux/macOS）
 - 自動起動設定（Windows: スタートアップショートカット、Linux: XDG autostart、macOS: launchd エージェント）
 
 ### 更新


### PR DESCRIPTION
## Summary
- PATH 登録を廃止し、スタートメニューショートカットで GUI を起動する方式に変更
- `update.bat` / `uninstall.bat` をインストール先にコピーするよう追加（ダブルクリックで実行可能に）
- `muhenkan.kbd` 内の `muhenkan-switch-core` を絶対パスに自動置換（PATH 不要化の対応）

## Test plan
- [ ] ワンライナーまたは `install.bat` でインストール
- [ ] インストール先に `update.bat`, `uninstall.bat` が存在すること
- [ ] スタートメニューで「muhenkan」を検索 → muhenkan-switch が表示されること
- [ ] スタートメニューから起動 → GUI + kanata が正常動作
- [ ] コマンドプロンプトで `muhenkan` を入力しても補完されないこと（PATH 未登録）
- [ ] `update.bat` ダブルクリックで更新処理が動くこと
- [ ] `uninstall.bat` でアンインストール → スタートメニューからも消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)