### PR TITLE
feat: 無変換+F1 で GUI 設定ウィンドウを前面に出す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 *.dll
 /kanata_cmd_allowed
 /muhenkan-switch-core
+!/muhenkan-switch-core/
 /muhenkan-switch
 !/muhenkan-switch/
 /bin/

--- a/kanata/muhenkan-macos.kbd
+++ b/kanata/muhenkan-macos.kbd
@@ -60,6 +60,9 @@
   ;; インデント操作
   indent (macro spc spc spc spc)
   dedent (macro home del del del del)
+
+  ;; GUI 設定ウィンドウを前面に出す
+  open-gui (cmd muhenkan-switch-core open-gui)
 )
 
 (deflayer default
@@ -87,5 +90,5 @@
   C-left  C-right  home  end
   bspc  del  esc
   @dedent  @indent
-  f1
+  @open-gui
 )

--- a/kanata/muhenkan.kbd
+++ b/kanata/muhenkan.kbd
@@ -68,6 +68,9 @@
   ;; インデント操作
   indent (macro spc spc spc spc)
   dedent (macro home del del del del)
+
+  ;; GUI 設定ウィンドウを前面に出す
+  open-gui (cmd muhenkan-switch-core open-gui)
 )
 
 ;; ── デフォルトレイヤー ──
@@ -107,6 +110,6 @@
   bspc  del  esc
   ;; インデント操作（IMEオフ時のインデント/逆インデント）
   @dedent  @indent
-  ;; F1 → 設定（将来実装）
-  f1
+  ;; F1 → GUI 設定ウィンドウを前面に出す
+  @open-gui
 )

--- a/muhenkan-switch-core/src/commands/mod.rs
+++ b/muhenkan-switch-core/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod dispatch;
 pub mod keys;
 pub mod open_folder;
+pub mod open_gui;
 pub mod search;
 pub mod switch_app;
 pub mod timestamp;

--- a/muhenkan-switch-core/src/commands/open_gui.rs
+++ b/muhenkan-switch-core/src/commands/open_gui.rs
@@ -1,0 +1,301 @@
+use anyhow::Result;
+use std::path::PathBuf;
+
+/// GUI バイナリ名
+const fn gui_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "muhenkan-switch.exe"
+    } else {
+        "muhenkan-switch"
+    }
+}
+
+/// GUI バイナリのフルパスを取得する。
+///
+/// 探索順序:
+/// 1. exe（muhenkan-switch-core）と同じディレクトリ（インストール環境）
+/// 2. カレントディレクトリの bin/（開発環境: mise run build 後）
+/// 3. ワークスペースルートの bin/（開発環境）
+/// 4. target/debug/（cargo build 直後）
+fn gui_binary_path() -> Option<PathBuf> {
+    let name = gui_binary_name();
+
+    // 1. exe と同じディレクトリ
+    if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
+        let path = exe_dir.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.to_path_buf());
+
+    // 2. カレントディレクトリの bin/
+    if let Ok(cwd) = std::env::current_dir() {
+        let path = cwd.join("bin").join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // 3. ワークスペースルートの bin/
+    if let Some(ref root) = workspace_root {
+        let path = root.join("bin").join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // 4. target/debug/
+    if let Some(ref root) = workspace_root {
+        let path = root.join("target").join("debug").join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+pub fn run() -> Result<()> {
+    imp::open_gui()
+}
+
+// ── Platform: Windows ──
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows::Win32::Foundation::{HWND, LPARAM};
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_MENU,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetForegroundWindow, GetWindowThreadProcessId, IsIconic, SetForegroundWindow,
+        ShowWindow, SW_RESTORE, SW_SHOW,
+    };
+    use windows::core::BOOL;
+
+    pub(super) fn open_gui() -> Result<()> {
+        // --- Step 1: Find PIDs matching "muhenkan-switch" ---
+        let app_lower = "muhenkan-switch";
+        let mut pids = Vec::new();
+
+        unsafe {
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)?;
+            let mut entry = PROCESSENTRY32W {
+                dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+                ..Default::default()
+            };
+
+            if Process32FirstW(snapshot, &mut entry).is_ok() {
+                loop {
+                    let exe_len = entry
+                        .szExeFile
+                        .iter()
+                        .position(|&c| c == 0)
+                        .unwrap_or(entry.szExeFile.len());
+                    let exe_name = OsString::from_wide(&entry.szExeFile[..exe_len])
+                        .to_string_lossy()
+                        .to_ascii_lowercase();
+                    if exe_name == app_lower || exe_name == format!("{}.exe", app_lower) {
+                        pids.push(entry.th32ProcessID);
+                    }
+                    if Process32NextW(snapshot, &mut entry).is_err() {
+                        break;
+                    }
+                }
+            }
+            let _ = windows::Win32::Foundation::CloseHandle(snapshot);
+        }
+
+        if pids.is_empty() {
+            return launch_gui();
+        }
+
+        // --- Step 2: Find a top-level window belonging to the GUI process ---
+        // IsWindowVisible チェックを外すことで、トレイ格納中（非表示）の
+        // ウィンドウも対象にする。
+        struct CallbackData {
+            pids: Vec<u32>,
+            hwnd: Option<HWND>,
+        }
+
+        unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+            let data = &mut *(lparam.0 as *mut CallbackData);
+            let mut pid: u32 = 0;
+            GetWindowThreadProcessId(hwnd, Some(&mut pid));
+            if data.pids.contains(&pid) {
+                data.hwnd = Some(hwnd);
+                return BOOL(0); // stop enumeration
+            }
+            BOOL(1) // continue
+        }
+
+        let mut data = CallbackData { pids, hwnd: None };
+        unsafe {
+            let _ = EnumWindows(
+                Some(enum_callback),
+                LPARAM(&mut data as *mut CallbackData as isize),
+            );
+        }
+
+        let hwnd = match data.hwnd {
+            Some(h) => h,
+            None => return Ok(()),
+        };
+
+        // --- Step 3: Show and activate the window ---
+        unsafe {
+            let fg_hwnd = GetForegroundWindow();
+            let fg_thread = GetWindowThreadProcessId(fg_hwnd, None);
+            let cur_thread = GetCurrentThreadId();
+
+            let attached = if fg_thread != cur_thread {
+                AttachThreadInput(cur_thread, fg_thread, true).as_bool()
+            } else {
+                false
+            };
+
+            // Alt press/release でフォアグラウンド権限を取得
+            let alt_down = INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_MENU,
+                        ..Default::default()
+                    },
+                },
+            };
+            let alt_up = INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_MENU,
+                        dwFlags: KEYEVENTF_KEYUP,
+                        ..Default::default()
+                    },
+                },
+            };
+            SendInput(&[alt_down, alt_up], size_of::<INPUT>() as i32);
+
+            // トレイ格納中（非表示）のウィンドウも表示する
+            let _ = ShowWindow(hwnd, SW_SHOW);
+            if IsIconic(hwnd).as_bool() {
+                let _ = ShowWindow(hwnd, SW_RESTORE);
+            }
+            let _ = SetForegroundWindow(hwnd);
+
+            if attached {
+                let _ = AttachThreadInput(cur_thread, fg_thread, false);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn launch_gui() -> Result<()> {
+        use std::os::windows::process::CommandExt;
+        use std::process::Command;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        let path = super::gui_binary_path()
+            .ok_or_else(|| anyhow::anyhow!("muhenkan-switch の実行ファイルが見つかりません"))?;
+
+        Command::new(path)
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()?;
+        Ok(())
+    }
+}
+
+// ── Platform: Linux ──
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::*;
+    use std::process::Command;
+
+    pub(super) fn open_gui() -> Result<()> {
+        let activated = try_wmctrl("muhenkan-switch")
+            || try_xdotool("muhenkan-switch", "--class")
+            || try_xdotool("muhenkan-switch", "--name");
+
+        if !activated {
+            launch_gui()?;
+        }
+
+        Ok(())
+    }
+
+    fn try_wmctrl(app: &str) -> bool {
+        Command::new("wmctrl")
+            .args(["-x", "-a", app])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn try_xdotool(app: &str, search_flag: &str) -> bool {
+        let result = Command::new("xdotool")
+            .args(["search", "--onlyvisible", search_flag, app])
+            .output();
+        match result {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if let Some(wid) = stdout.lines().next() {
+                    Command::new("xdotool")
+                        .args(["windowactivate", "--sync", wid])
+                        .output()
+                        .map(|o| o.status.success())
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn launch_gui() -> Result<()> {
+        let path = super::gui_binary_path()
+            .ok_or_else(|| anyhow::anyhow!("muhenkan-switch の実行ファイルが見つかりません"))?;
+        Command::new(path).spawn()?;
+        Ok(())
+    }
+}
+
+// ── Platform: macOS ──
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::*;
+    use std::process::Command;
+
+    pub(super) fn open_gui() -> Result<()> {
+        // osascript の activate は未起動なら起動、起動済みなら前面化する
+        let ok = Command::new("osascript")
+            .args(["-e", r#"tell application "muhenkan-switch" to activate"#])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        if !ok {
+            // アプリ未登録など osascript が失敗した場合はバイナリを直接起動
+            if let Some(path) = super::gui_binary_path() {
+                Command::new(path).spawn()?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/muhenkan-switch-core/src/commands/open_gui.rs
+++ b/muhenkan-switch-core/src/commands/open_gui.rs
@@ -10,6 +10,12 @@ const fn gui_binary_name() -> &'static str {
     }
 }
 
+/// GUI 起動要求のシグナルファイルパス。
+/// open-gui が書き込み、GUI プロセス側の監視スレッドが検出して削除する。
+pub fn signal_file_path() -> PathBuf {
+    std::env::temp_dir().join("muhenkan-switch-show.signal")
+}
+
 /// GUI バイナリのフルパスを取得する。
 ///
 /// 探索順序:
@@ -70,25 +76,24 @@ mod imp {
     use super::*;
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
-    use windows::Win32::Foundation::{HWND, LPARAM};
     use windows::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
         TH32CS_SNAPPROCESS,
     };
-    use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_MENU,
-    };
-    use windows::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetForegroundWindow, GetWindowThreadProcessId, IsIconic, SetForegroundWindow,
-        ShowWindow, SW_RESTORE, SW_SHOW,
-    };
-    use windows::core::BOOL;
 
     pub(super) fn open_gui() -> Result<()> {
-        // --- Step 1: Find PIDs matching "muhenkan-switch" ---
+        if is_gui_running()? {
+            // GUI が起動済み → シグナルファイルを書いて表示を依頼
+            std::fs::write(super::signal_file_path(), b"")?;
+        } else {
+            // GUI が未起動 → バイナリを起動
+            launch_gui()?;
+        }
+        Ok(())
+    }
+
+    fn is_gui_running() -> Result<bool> {
         let app_lower = "muhenkan-switch";
-        let mut pids = Vec::new();
 
         unsafe {
             let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)?;
@@ -97,6 +102,7 @@ mod imp {
                 ..Default::default()
             };
 
+            let mut found = false;
             if Process32FirstW(snapshot, &mut entry).is_ok() {
                 loop {
                     let exe_len = entry
@@ -108,7 +114,8 @@ mod imp {
                         .to_string_lossy()
                         .to_ascii_lowercase();
                     if exe_name == app_lower || exe_name == format!("{}.exe", app_lower) {
-                        pids.push(entry.th32ProcessID);
+                        found = true;
+                        break;
                     }
                     if Process32NextW(snapshot, &mut entry).is_err() {
                         break;
@@ -116,91 +123,8 @@ mod imp {
                 }
             }
             let _ = windows::Win32::Foundation::CloseHandle(snapshot);
+            Ok(found)
         }
-
-        if pids.is_empty() {
-            return launch_gui();
-        }
-
-        // --- Step 2: Find a top-level window belonging to the GUI process ---
-        // IsWindowVisible チェックを外すことで、トレイ格納中（非表示）の
-        // ウィンドウも対象にする。
-        struct CallbackData {
-            pids: Vec<u32>,
-            hwnd: Option<HWND>,
-        }
-
-        unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
-            let data = &mut *(lparam.0 as *mut CallbackData);
-            let mut pid: u32 = 0;
-            GetWindowThreadProcessId(hwnd, Some(&mut pid));
-            if data.pids.contains(&pid) {
-                data.hwnd = Some(hwnd);
-                return BOOL(0); // stop enumeration
-            }
-            BOOL(1) // continue
-        }
-
-        let mut data = CallbackData { pids, hwnd: None };
-        unsafe {
-            let _ = EnumWindows(
-                Some(enum_callback),
-                LPARAM(&mut data as *mut CallbackData as isize),
-            );
-        }
-
-        let hwnd = match data.hwnd {
-            Some(h) => h,
-            None => return Ok(()),
-        };
-
-        // --- Step 3: Show and activate the window ---
-        unsafe {
-            let fg_hwnd = GetForegroundWindow();
-            let fg_thread = GetWindowThreadProcessId(fg_hwnd, None);
-            let cur_thread = GetCurrentThreadId();
-
-            let attached = if fg_thread != cur_thread {
-                AttachThreadInput(cur_thread, fg_thread, true).as_bool()
-            } else {
-                false
-            };
-
-            // Alt press/release でフォアグラウンド権限を取得
-            let alt_down = INPUT {
-                r#type: INPUT_KEYBOARD,
-                Anonymous: INPUT_0 {
-                    ki: KEYBDINPUT {
-                        wVk: VK_MENU,
-                        ..Default::default()
-                    },
-                },
-            };
-            let alt_up = INPUT {
-                r#type: INPUT_KEYBOARD,
-                Anonymous: INPUT_0 {
-                    ki: KEYBDINPUT {
-                        wVk: VK_MENU,
-                        dwFlags: KEYEVENTF_KEYUP,
-                        ..Default::default()
-                    },
-                },
-            };
-            SendInput(&[alt_down, alt_up], size_of::<INPUT>() as i32);
-
-            // トレイ格納中（非表示）のウィンドウも表示する
-            let _ = ShowWindow(hwnd, SW_SHOW);
-            if IsIconic(hwnd).as_bool() {
-                let _ = ShowWindow(hwnd, SW_RESTORE);
-            }
-            let _ = SetForegroundWindow(hwnd);
-
-            if attached {
-                let _ = AttachThreadInput(cur_thread, fg_thread, false);
-            }
-        }
-
-        Ok(())
     }
 
     fn launch_gui() -> Result<()> {
@@ -226,44 +150,20 @@ mod imp {
     use std::process::Command;
 
     pub(super) fn open_gui() -> Result<()> {
-        let activated = try_wmctrl("muhenkan-switch")
-            || try_xdotool("muhenkan-switch", "--class")
-            || try_xdotool("muhenkan-switch", "--name");
-
-        if !activated {
+        if is_gui_running() {
+            std::fs::write(super::signal_file_path(), b"")?;
+        } else {
             launch_gui()?;
         }
-
         Ok(())
     }
 
-    fn try_wmctrl(app: &str) -> bool {
-        Command::new("wmctrl")
-            .args(["-x", "-a", app])
+    fn is_gui_running() -> bool {
+        Command::new("pgrep")
+            .args(["-x", "muhenkan-switch"])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
-    }
-
-    fn try_xdotool(app: &str, search_flag: &str) -> bool {
-        let result = Command::new("xdotool")
-            .args(["search", "--onlyvisible", search_flag, app])
-            .output();
-        match result {
-            Ok(output) if output.status.success() => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                if let Some(wid) = stdout.lines().next() {
-                    Command::new("xdotool")
-                        .args(["windowactivate", "--sync", wid])
-                        .output()
-                        .map(|o| o.status.success())
-                        .unwrap_or(false)
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        }
     }
 
     fn launch_gui() -> Result<()> {
@@ -282,7 +182,9 @@ mod imp {
     use std::process::Command;
 
     pub(super) fn open_gui() -> Result<()> {
-        // osascript の activate は未起動なら起動、起動済みなら前面化する
+        // osascript の activate は未起動なら起動、起動済みなら前面化する。
+        // macOS は Tauri の WebviewWindow が osascript で正しく制御できるため
+        // シグナルファイル方式は不要。
         let ok = Command::new("osascript")
             .args(["-e", r#"tell application "muhenkan-switch" to activate"#])
             .output()
@@ -290,7 +192,6 @@ mod imp {
             .unwrap_or(false);
 
         if !ok {
-            // アプリ未登録など osascript が失敗した場合はバイナリを直接起動
             if let Some(path) = super::gui_binary_path() {
                 Command::new(path).spawn()?;
             }

--- a/muhenkan-switch-core/src/main.rs
+++ b/muhenkan-switch-core/src/main.rs
@@ -46,10 +46,18 @@ enum Commands {
         /// ディスパッチキー (config.toml の key フィールドに対応)
         key: String,
     },
+    /// GUI 設定ウィンドウを前面に出す（未起動なら起動する）
+    OpenGui,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // config 不要なコマンドは先に処理
+    if let Commands::OpenGui = cli.command {
+        return commands::open_gui::run();
+    }
+
     let config = config::load()?;
 
     match cli.command {
@@ -58,5 +66,6 @@ fn main() -> Result<()> {
         Commands::OpenFolder { target } => commands::open_folder::run(&target, &config),
         Commands::Timestamp { action } => commands::timestamp::run(&action, &config),
         Commands::Dispatch { key } => commands::dispatch::run(&key, &config),
+        Commands::OpenGui => unreachable!(),
     }
 }

--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -511,5 +511,24 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // シグナルファイル監視スレッド
+    // open-gui コマンドがシグナルファイルを書き込んだとき、
+    // GUI 自身の Tauri API 経由でウィンドウを表示・前面化する。
+    // （外部プロセスから直接 Win32 API を呼ぶと Tauri の内部状態とデシンクするため）
+    let signal_app = app.handle().clone();
+    std::thread::spawn(move || {
+        let signal_path = std::env::temp_dir().join("muhenkan-switch-show.signal");
+        loop {
+            std::thread::sleep(Duration::from_millis(200));
+            if signal_path.exists() {
+                let _ = std::fs::remove_file(&signal_path);
+                if let Some(window) = signal_app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+        }
+    });
+
     Ok(())
 }


### PR DESCRIPTION
Closes #16

## Summary

- `muhenkan-switch-core` に `open-gui` サブコマンドを追加
- 無変換+F1 で GUI 設定ウィンドウを前面に出す（未起動なら起動する）
- Windows / Linux / macOS 対応
- `.gitignore` の `/muhenkan-switch-core` ルールを修正（ソースディレクトリを誤除外していた）

### 実装方式: シグナルファイル IPC

Win32 直接操作（`SW_SHOW` / `SetForegroundWindow`）は Tauri の内部ウィンドウ状態とデシンクを起こすため採用しない。

```
open-gui プロセス                    GUI プロセス（Tauri）
  起動済み → シグナルファイルを書く  →  監視スレッド（200ms ポーリング）が検出
  未起動   → バイナリを launch            → window.show() + window.set_focus()
```

- `open_gui.rs`: プロセス存在確認 → 起動済みならシグナルファイル書き込み
- `kanata.rs`: `setup()` にシグナルファイル監視スレッドを追加

## Test plan

- [x] `cargo build --workspace` でビルド成功
- [x] `cargo test --workspace` で全テスト通過（34 tests）
- [x] `mise run dev` で `config file is valid` を確認
- [x] 無変換+F1 で `Running cmd: open-gui` / `Successfully ran cmd: open-gui` をログで確認
- [x] 初回起動 GUI ウィンドウへの前面化が動作することを確認
- [x] GUI をトレイに格納した状態で無変換+F1 を押してウィンドウが復元されることを確認
- [x] 復元したウィンドウの X ボタンで正常にトレイに格納できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)