### PR TITLE
feat: Windows .msi インストーラー対応 & LGPL-3.0 移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,6 @@ jobs:
             core_artifact: muhenkan-switch-core
             gui_artifact: muhenkan-switch
             asset_suffix: linux-x64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            core_artifact: muhenkan-switch-core.exe
-            gui_artifact: muhenkan-switch.exe
-            asset_suffix: windows-x64
           - os: macos-latest
             target: x86_64-apple-darwin
             core_artifact: muhenkan-switch-core
@@ -80,14 +75,6 @@ jobs:
 
           # インストール/アンインストールスクリプト
           case "${{ matrix.asset_suffix }}" in
-            windows-x64)
-              cp scripts/install.ps1 "$RELEASE_DIR/"
-              cp scripts/uninstall.ps1 "$RELEASE_DIR/"
-              cp scripts/update.ps1 "$RELEASE_DIR/"
-              cp scripts/install.bat "$RELEASE_DIR/"
-              cp scripts/uninstall.bat "$RELEASE_DIR/"
-              cp scripts/update.bat "$RELEASE_DIR/"
-              ;;
             linux-x64)
               cp scripts/install.sh "$RELEASE_DIR/"
               cp scripts/uninstall.sh "$RELEASE_DIR/"
@@ -108,20 +95,89 @@ jobs:
           tar czf "muhenkan-switch-rs-${{ matrix.asset_suffix }}.tar.gz" \
             "muhenkan-switch-rs-${{ matrix.asset_suffix }}/"
 
-      - name: Create archive (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Compress-Archive -Path "muhenkan-switch-rs-${{ matrix.asset_suffix }}" `
-            -DestinationPath "muhenkan-switch-rs-${{ matrix.asset_suffix }}.zip"
-
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.asset_suffix }}
           path: muhenkan-switch-rs-${{ matrix.asset_suffix }}.*
 
+  build-windows-msi:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      # 1. muhenkan-switch-core をビルド
+      - name: Build muhenkan-switch-core
+        run: cargo build --release --target x86_64-pc-windows-msvc -p muhenkan-switch-core
+
+      # 2. sidecar 用ディレクトリに target-triple 付きでコピー
+      - name: Prepare muhenkan-switch-core sidecar
+        shell: bash
+        run: |
+          mkdir -p muhenkan-switch/binaries
+          cp target/x86_64-pc-windows-msvc/release/muhenkan-switch-core.exe \
+             muhenkan-switch/binaries/muhenkan-switch-core-x86_64-pc-windows-msvc.exe
+
+      # 3. kanata をダウンロードして sidecar 配置
+      - name: Download kanata and prepare sidecar
+        shell: pwsh
+        run: |
+          $version = (Get-Content kanata-version.txt).Trim()
+          $url = "https://github.com/jtroo/kanata/releases/download/${version}/kanata_cmd_allowed.exe"
+          Write-Host "Downloading kanata ${version} from ${url}"
+          Invoke-WebRequest -Uri $url -OutFile "muhenkan-switch/binaries/kanata_cmd_allowed-x86_64-pc-windows-msvc.exe"
+
+      # 4. cargo tauri build で .msi / NSIS .exe を生成
+      - name: Build Windows installer (.msi and NSIS)
+        run: npx --yes @tauri-apps/cli@2 build --target x86_64-pc-windows-msvc --bundle msi,nsis
+        working-directory: muhenkan-switch
+
+      # 5. 生成されたインストーラーを artifacts にアップロード
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-msi
+          path: |
+            muhenkan-switch/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+            muhenkan-switch/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+
+      # 6. Power User 向け zip もビルド・パッケージ
+      - name: Package zip release (Power User)
+        shell: bash
+        run: |
+          RELEASE_DIR="muhenkan-switch-rs-windows-x64"
+          mkdir -p "$RELEASE_DIR"
+
+          cp target/x86_64-pc-windows-msvc/release/muhenkan-switch-core.exe "$RELEASE_DIR/"
+          cp target/x86_64-pc-windows-msvc/release/muhenkan-switch.exe "$RELEASE_DIR/" 2>/dev/null || true
+          cp config/default.toml "$RELEASE_DIR/config.toml"
+          cp kanata/muhenkan.kbd "$RELEASE_DIR/"
+          cp kanata/muhenkan-macos.kbd "$RELEASE_DIR/"
+          cp README.md "$RELEASE_DIR/"
+          cp scripts/install.ps1 "$RELEASE_DIR/"
+          cp scripts/uninstall.ps1 "$RELEASE_DIR/"
+          cp scripts/update.ps1 "$RELEASE_DIR/"
+          cp scripts/install.bat "$RELEASE_DIR/"
+          cp scripts/uninstall.bat "$RELEASE_DIR/"
+          cp scripts/update.bat "$RELEASE_DIR/"
+
+      - name: Create zip archive (Windows)
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "muhenkan-switch-rs-windows-x64" `
+            -DestinationPath "muhenkan-switch-rs-windows-x64.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-x64
+          path: muhenkan-switch-rs-windows-x64.*
+
   release:
-    needs: build
+    needs: [build, build-windows-msi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -134,30 +190,32 @@ jobs:
           files: |
             muhenkan-switch-rs-*.tar.gz
             muhenkan-switch-rs-*.zip
+            *.msi
+            *-setup.exe
           body: |
             ## muhenkan-switch-rs
 
-            ### ワンライナーインストール（推奨）
+            ### Windows インストール（推奨）
+
+            1. 下記から `muhenkan-switch_x64.msi`（または `_x64-setup.exe`）をダウンロード
+            2. ダブルクリックしてインストール
+            3. スタートメニューから muhenkan-switch を起動
+
+            ### Linux / macOS インストール
 
             **Linux / macOS:**
             ```bash
             curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.sh | sh
             ```
 
-            **Windows (PowerShell):**
+            **Windows（上級者向け PowerShell ワンライナー）:**
             ```powershell
             irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.ps1 | iex
             ```
 
-            ### 手動インストール
-            1. アーカイブをダウンロード・展開
-            2. インストールスクリプトを実行
-               - **Windows**: `install.bat` をダブルクリック、または `install.ps1` を右クリック →「PowerShell で実行」
-               - **Linux**: `./install.sh`
-               - **macOS**: `./install-macos.sh`
-
             ### ダウンロード
-            - **Windows (x64)**: `muhenkan-switch-rs-windows-x64.zip`
+            - **Windows (x64) インストーラー**: `muhenkan-switch_x64.msi` / `muhenkan-switch_x64-setup.exe`
+            - **Windows (x64) zip（上級者向け）**: `muhenkan-switch-rs-windows-x64.zip`
             - **Linux (x64)**: `muhenkan-switch-rs-linux-x64.tar.gz`
             - **macOS (x64)**: `muhenkan-switch-rs-macos-x64.tar.gz` ⚠️ 未検証
             - **macOS (ARM)**: `muhenkan-switch-rs-macos-arm64.tar.gz` ⚠️ 未検証

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [workspace.package]
 version = "0.3.0"
 edition = "2021"
-license = "GPL-2.0-only"
+license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch-rs"
 
 [workspace.dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,338 +1,174 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+This repository (muhenkan-switch-rs) is licensed under the GNU Lesser General
+Public License v3.0 (LGPL-3.0-only).
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- <https://fsf.org/>
+This repository bundles kanata (https://github.com/jtroo/kanata) in binary form.
+kanata is also licensed under the GNU Lesser General Public License v3.0
+(LGPL-3.0). kanata's source code is available at the URL above.
+
+-------------------------------------------------------------------------------
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-                            Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
-your programs, too.
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
 
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+  0. Additional Definitions.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
 
-  The precise terms and conditions for copying, distribution and
-modification follow.
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+  1. Exception to Section 3 of the GNU GPL.
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  2. Conveying Modified Versions.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  3. Object Code Incorporating Material from Library Header Files.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  4. Combined Works.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+   d) Do one of the following:
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  5. Combined Libraries.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
-this License.
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  6. Revised Versions of the GNU Lesser General Public License.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
 
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
 
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
-
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
-
-                            NO WARRANTY
-
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
-
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
-
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
-
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
-
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Moe Ghoul>, 1 April 1989
-  Moe Ghoul, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -135,12 +135,25 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 ### アンインストール
 
-インストール先にあるアンインストールスクリプトを実行してください:
+#### Windows（.msi でインストールした場合）
 
-```bash
+**設定 → アプリ → muhenkan-switch → アンインストール** で削除できます。
+.msi インストーラーは Windows の標準的な仕組みに従って登録されているため、
+スクリプト不要でコントロールパネルからアンインストールできます。
+
+<details>
+<summary>zip 版（上級者向け）でインストールした場合</summary>
+
+```powershell
 # Windows（PowerShell）
 & "$env:LOCALAPPDATA\muhenkan-switch-rs\uninstall.ps1"
+```
 
+</details>
+
+#### Linux / macOS
+
+```bash
 # Linux
 ~/.local/share/muhenkan-switch-rs/uninstall.sh
 
@@ -148,31 +161,37 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 ~/Library/Application\ Support/muhenkan-switch-rs/uninstall-macos.sh
 ```
 
-手動で削除する場合は、以下を削除してください:
-- インストールディレクトリ（上記表を参照）
-- スタートメニューショートカット（Windows）/ PATH のシンボリックリンク（Linux/macOS）
-- 自動起動設定（Windows: スタートアップショートカット、Linux: XDG autostart、macOS: launchd エージェント）
-
 ### 更新
 
-インストール先にある更新スクリプトを実行すると、最新版に更新できます。
+#### Windows（.msi でインストールした場合）
 
-```
+[最新リリース](https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest) から
+新しい `.msi` をダウンロードしてダブルクリックするだけで上書き更新されます。
+
+<details>
+<summary>zip 版（上級者向け）でインストールした場合</summary>
+
+```powershell
 # Windows（PowerShell）
 & "$env:LOCALAPPDATA\muhenkan-switch-rs\update.ps1"
+```
 
+更新スクリプトは以下を自動で行います:
+- GitHub Releases から最新バージョンの確認
+- 現在のバージョンとの比較（既に最新の場合は終了）
+- 最新版のダウンロード・展開・インストール
+
+</details>
+
+#### Linux / macOS
+
+```bash
 # Linux
 ~/.local/share/muhenkan-switch-rs/update.sh
 
 # macOS
 ~/Library/Application\ Support/muhenkan-switch-rs/update-macos.sh
 ```
-
-更新スクリプトは以下を自動で行います:
-- GitHub Releases から最新バージョンの確認
-- 現在のバージョンとの比較（既に最新の場合は終了）
-- 最新版のダウンロード・展開
-- インストールスクリプトの実行（既存インストールを上書き更新）
 
 ## macOS をお使いの方へ
 

--- a/README.md
+++ b/README.md
@@ -34,30 +34,31 @@
 
 ### 1. インストール
 
+#### Windows
+
+1. [最新リリース](https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest) から
+   `muhenkan-switch_x64.msi`（または `muhenkan-switch_x64-setup.exe`）をダウンロード
+2. ダブルクリックしてインストール
+3. スタートメニューから `muhenkan-switch` を起動
+
+> **PowerShell ワンライナーでのインストール（上級者向け）:**
+> ```powershell
+> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.ps1 | iex
+> ```
+
+#### Linux / macOS
+
 以下のコマンドをターミナルに貼り付けて実行するだけで、最新版のダウンロードからインストールまで自動で行われます。
 
-**Linux / macOS:**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.sh | sh
 ```
 
-**Windows (PowerShell):**
-```powershell
-irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.ps1 | iex
-```
-
 > **セキュリティについて**: スクリプトの内容を事前に確認したい場合は、先にダウンロードしてから実行できます。
 > ```bash
-> # Linux / macOS
 > curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.sh -o get.sh
 > less get.sh    # 内容を確認
 > bash get.sh    # 実行
-> ```
-> ```powershell
-> # Windows
-> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/get.ps1 -OutFile get.ps1
-> Get-Content get.ps1   # 内容を確認
-> .\get.ps1             # 実行
 > ```
 
 <details>
@@ -278,7 +279,13 @@ mise run test       # ユニットテスト
 
 ## ライセンス
 
-GPL-2.0 — [muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch) を継承。
+LGPL-3.0-only
+
+本プロジェクト（muhenkan-switch-rs）は Rust によるフルスクラッチ実装です。
+旧版（[muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch) AutoHotkey 版）の仕様を継承していますが、
+コードの流用はないため LGPL-3.0 で提供します。
+
+同梱する kanata も LGPL-3.0 です（`LICENSE` 参照）。
 
 ## 旧版（AutoHotkey版）
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,7 +20,7 @@ summary: muhenkan-switchをkanata＋Rust製muhenkan-switchバイナリ構成でW
 - 対象OS: Windows / macOS / Linux
 - macOS は設定ファイルを提供するが、**開発者の検証環境がないため未検証**
 - **JIS配列キーボード前提**。US配列は考慮しない
-- ライセンス: GPL-2.0（現行を継承）
+- ライセンス: LGPL-3.0-only
 
 **設計方針:**
 - kanata を外部バイナリとして利用（クレート組み込みはしない）

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -36,6 +36,18 @@ fn main() {
             commands::validate_timestamp_format,
         ])
         .setup(|app| {
+            // 初回起動時: exe 同梱ディレクトリに config.toml がなければデフォルト設定を生成
+            if let Ok(exe_path) = std::env::current_exe() {
+                if let Some(exe_dir) = exe_path.parent() {
+                    let config_path = exe_dir.join("config.toml");
+                    if !config_path.exists() {
+                        let default = muhenkan_switch_config::default_config();
+                        if let Err(e) = muhenkan_switch_config::save(&config_path, &default) {
+                            eprintln!("[setup] config.toml の生成に失敗: {:#}", e);
+                        }
+                    }
+                }
+            }
             tray::setup(app)?;
             kanata::setup(app)?;
             Ok(())

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -31,6 +31,18 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "externalBin": [
+      "binaries/kanata_cmd_allowed",
+      "binaries/muhenkan-switch-core"
+    ],
+    "resources": {
+      "../kanata/muhenkan.kbd": "./"
+    },
+    "licenseFile": "../LICENSE",
+    "windows": {
+      "wix": {},
+      "nsis": {}
+    }
   }
 }


### PR DESCRIPTION
## 概要

Closes #12

ターミナル不要で Windows にインストールできるよう `.msi` / NSIS インストーラーのビルドパイプラインを整備した。
あわせてライセンスを LGPL-3.0 に移行した。

## 変更内容

### Windows .msi インストーラー対応

- `muhenkan-switch/tauri.conf.json`: `externalBin`（kanata・muhenkan-switch-core）、`resources`（muhenkan.kbd）、`licenseFile`、`windows` バンドル設定を追加
- `muhenkan-switch/src/main.rs`: 初回起動時に `config.toml` が存在しなければデフォルト設定を自動生成
- `.github/workflows/release.yml`: Windows ジョブを `build-windows-msi` として分離。sidecar バイナリ準備 → `cargo tauri build --bundle msi,nsis` の手順に変更。zip パッケージ（Power User 向け）は引き続き生成
- `README.md`: Windows インストール手順を `.msi` ダウンロード優先に更新。アンインストールは設定→アプリから、アップデートは新しい `.msi` をダブルクリックするだけでよいことを明記

### ライセンス LGPL-3.0 移行

本実装は AutoHotkey 版の仕様を継承しているが、コードの流用はなく Rust によるフルスクラッチ実装のため GPL-2.0-only の制約を受けない。同梱する kanata も LGPL-3.0 であり `LICENSE` に統合した。

- `Cargo.toml`: `license = "LGPL-3.0-only"`
- `LICENSE`: GPL-2.0 全文 → LGPL-3.0 全文 + kanata 帰属表記に差し替え
- `README.md` / `docs/design.md`: ライセンス記載を更新

## 検証方法

1. CI の `build-windows-msi` ジョブが成功し `.msi` が GitHub Release に添付されることを確認
2. `.msi` をダブルクリック → インストールウィザードが起動することを確認
3. スタートメニューから `muhenkan-switch` を起動 → トレイアイコンが表示されることを確認
4. 無変換キーのショートカットが動作することを確認
5. 設定→アプリからアンインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)