### PR TITLE
chore: バージョンを 0.4.0 に更新

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch-rs"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend"


### PR DESCRIPTION
## 概要

v0.4.0 リリースに向けてバージョン番号を更新する。

- `Cargo.toml`: `0.3.0` → `0.4.0`
- `muhenkan-switch/tauri.conf.json`: `0.3.0` → `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)