### PR TITLE
fix: --bundle を --bundles に修正（Tauri CLI オプション名）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
 
       # 4. cargo tauri build で .msi / NSIS .exe を生成
       - name: Build Windows installer (.msi and NSIS)
-        run: npx --yes @tauri-apps/cli@2 build --target x86_64-pc-windows-msvc --bundle msi,nsis
+        run: npx --yes @tauri-apps/cli@2 build --target x86_64-pc-windows-msvc --bundles msi,nsis
         working-directory: muhenkan-switch
 
       # 5. 生成されたインストーラーを artifacts にアップロード


### PR DESCRIPTION
## 問題

```
error: unexpected argument '--bundle' found
  tip: a similar argument exists: '--bundles'
```

Tauri CLI v2 のオプション名は `--bundles`（複数形）だが `--bundle` と記述していた。

## 修正

```yaml
- npx ... build --bundle msi,nsis
+ npx ... build --bundles msi,nsis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)