### PR TITLE
fix: .msi アーティファクトのパスを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,13 +153,14 @@ jobs:
         working-directory: muhenkan-switch
 
       # 5. 生成されたインストーラーを artifacts にアップロード
+      #    Cargo ワークスペースの target/ はルートに置かれるため muhenkan-switch/ プレフィックスは不要
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-msi
           path: |
-            muhenkan-switch/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
-            muhenkan-switch/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+            target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
 
       # 6. Power User 向け zip もビルド・パッケージ
       - name: Package zip release (Power User)


### PR DESCRIPTION
## 問題

```
No files were found with the provided path: muhenkan-switch/target/.../bundle/msi/*.msi
```

Cargo ワークスペースでは `target/` はワークスペースルートに置かれる。
`working-directory: muhenkan-switch` でビルドしても出力先は `target/`（ルート）であり `muhenkan-switch/target/` ではない。

## 修正

```yaml
- muhenkan-switch/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+ target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)