### PR TITLE
fix: release の .msi / .exe グロブパターンを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,8 +207,8 @@ jobs:
           files: |
             muhenkan-switch-rs-*.tar.gz
             muhenkan-switch-rs-*.zip
-            *.msi
-            *-setup.exe
+            msi/*.msi
+            nsis/*-setup.exe
           body: |
             ## muhenkan-switch-rs
 


### PR DESCRIPTION
## 問題

```
🤔 Pattern '*.msi' does not match any files.
🤔 Pattern '*-setup.exe' does not match any files.
```

`actions/upload-artifact@v4` は複数サブディレクトリのファイルをアップロードする際に
ディレクトリ構造を保持する（least common ancestor をルートとする）。

ダウンロード後の構造:
```
msi/muhenkan-switch_0.4.0_x64_en-US.msi
nsis/muhenkan-switch_0.4.0_x64-setup.exe
```

`*.msi` というフラットなグロブではマッチしない。

## 修正

```yaml
- *.msi
- *-setup.exe
+ msi/*.msi
+ nsis/*-setup.exe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)