### PR TITLE
fix: デフォルト設定をバイナリに埋め込みインストール環境で正しく初期化

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -103,7 +103,8 @@ import os, sys, platform, zipfile, urllib.request, shutil
 
 VERSION = "v1.11.0"
 ext = ".exe" if os.name == "nt" else ""
-dest = f"./kanata_cmd_allowed{ext}"
+os.makedirs("./bin", exist_ok=True)
+dest = f"./bin/kanata_cmd_allowed{ext}"
 
 if os.path.exists(dest):
     print("[fetch-kanata] kanata_cmd_allowed already exists -- skipping.")
@@ -180,10 +181,27 @@ EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
 # Linux ではバイナリ名と crate ディレクトリ名が衝突するため bin/ にコピー
 mkdir -p ./bin
 cp "target/debug/muhenkan-switch-core${EXT}" "./bin/muhenkan-switch-core${EXT}"
-echo "[dev] Copied -> ./bin/muhenkan-switch-core${EXT}"
+echo "[build] Copied -> ./bin/muhenkan-switch-core${EXT}"
 if [ -f "target/debug/muhenkan-switch${EXT}" ]; then
   cp "target/debug/muhenkan-switch${EXT}" "./bin/muhenkan-switch${EXT}"
-  echo "[dev] Copied -> ./bin/muhenkan-switch${EXT}"
+  echo "[build] Copied -> ./bin/muhenkan-switch${EXT}"
+fi
+
+# muhenkan.kbd を bin/ にコピー（常に最新を反映）
+cp kanata/muhenkan.kbd ./bin/muhenkan.kbd
+echo "[build] Copied -> ./bin/muhenkan.kbd"
+
+# config.toml が bin/ になければ OS 別デフォルトからコピー
+# （ユーザーが bin/config.toml を編集している場合は上書きしない）
+if [ ! -f "./bin/config.toml" ]; then
+  if [ "$OS" = "Windows_NT" ]; then
+    cp config/default-windows.toml ./bin/config.toml
+  elif [ "$(uname)" = "Darwin" ]; then
+    cp config/default-macos.toml ./bin/config.toml
+  else
+    cp config/default-linux.toml ./bin/config.toml
+  fi
+  echo "[build] Created ./bin/config.toml from default"
 fi
 """
 
@@ -208,8 +226,9 @@ description = "Build and start GUI"
 depends = ["build", "fetch-kanata"]
 shell = "bash -c"
 run = """
-echo "[dev] Starting GUI..."
-cargo run -p muhenkan-switch
+EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
+echo "[dev] Starting GUI from ./bin/ ..."
+./bin/muhenkan-switch${EXT}
 """
 
 [tasks.gen-icons]

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -154,22 +154,11 @@ fn default_delimiter() -> String {
 
 // ── Config path resolution ──
 
-/// 実行中の OS に対応するデフォルト設定ファイル名を返す。
-fn os_default_config_name() -> &'static str {
-    match std::env::consts::OS {
-        "windows" => "default-windows.toml",
-        "macos" => "default-macos.toml",
-        _ => "default-linux.toml",
-    }
-}
-
 /// config.toml のパスを決定する。
 /// 優先順位:
-/// 1. 実行ファイルと同じディレクトリの config.toml（インストール環境）
-/// 2. カレントディレクトリの config.toml
-/// 3. ワークスペースルートの config/default-{os}.toml（開発環境、OS別）
-/// 4. ワークスペースルートの config/default.toml（開発環境、フォールバック）
-/// 5. 見つからなければ None
+/// 1. 実行ファイルと同じディレクトリの config.toml（インストール環境 / dev: ./bin/ 実行時）
+/// 2. CARGO_MANIFEST_DIR/../bin/config.toml（開発環境: cargo run 互換）
+/// 3. 見つからなければ None（default_config() の embedded config で補完）
 pub fn config_path() -> Option<PathBuf> {
     // 1. 実行ファイルと同じディレクトリ
     if let Ok(exe_path) = std::env::current_exe() {
@@ -181,24 +170,12 @@ pub fn config_path() -> Option<PathBuf> {
         }
     }
 
-    // 2. カレントディレクトリ
-    let path = PathBuf::from("config.toml");
-    if path.exists() {
-        return Some(path);
-    }
-
-    // 3 & 4. ワークスペースルートの config/（開発環境）
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    // 2. ワークスペースルートの bin/（開発環境）
+    let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
-        .map(|p| p.to_path_buf());
-    if let Some(ref root) = workspace_root {
-        // OS 別ファイルを優先
-        let os_path = root.join("config").join(os_default_config_name());
-        if os_path.exists() {
-            return Some(os_path);
-        }
-        // 共通フォールバック
-        let path = root.join("config").join("default.toml");
+        .map(|p| p.join("bin"));
+    if let Some(ref dir) = bin_dir {
+        let path = dir.join("config.toml");
         if path.exists() {
             return Some(path);
         }

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -227,36 +227,32 @@ pub fn load() -> Result<Config> {
     }
 }
 
+// デフォルト設定ファイルをコンパイル時にバイナリへ埋め込む。
+// インストール済み環境でも env!("CARGO_MANIFEST_DIR") に依存せず参照できる。
+const DEFAULT_WINDOWS_CONFIG: &str = include_str!("../../config/default-windows.toml");
+const DEFAULT_LINUX_CONFIG: &str = include_str!("../../config/default-linux.toml");
+const DEFAULT_MACOS_CONFIG: &str = include_str!("../../config/default-macos.toml");
+const DEFAULT_CONFIG: &str = include_str!("../../config/default.toml");
+
 /// デフォルト設定を返す。
-/// config/default-{os}.toml → config/default.toml → 最小限のフォールバックの順で試みる。
+/// バイナリに埋め込まれた OS 別デフォルト設定 → 共通デフォルト → 最小限フォールバックの順で試みる。
 pub fn default_config() -> Config {
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .map(|p| p.to_path_buf());
-    if let Some(ref root) = workspace_root {
-        // OS 別ファイルを優先
-        let os_path = root.join("config").join(os_default_config_name());
-        if let Ok(config) = load_from(&os_path) {
-            return config;
-        }
-        // 共通フォールバック
-        let path = root.join("config").join("default.toml");
-        if let Ok(config) = load_from(&path) {
-            return config;
-        }
+    // 1. OS 別埋め込みデフォルト設定（コンパイル時にバイナリに組み込み済み）
+    let os_default = match std::env::consts::OS {
+        "windows" => DEFAULT_WINDOWS_CONFIG,
+        "macos" => DEFAULT_MACOS_CONFIG,
+        _ => DEFAULT_LINUX_CONFIG,
+    };
+    if let Ok(config) = toml::from_str(os_default) {
+        return config;
     }
 
-    // exe と同じディレクトリの config.toml（インストール環境の初期値）
-    if let Ok(exe_path) = std::env::current_exe() {
-        if let Some(dir) = exe_path.parent() {
-            let path = dir.join("config.toml");
-            if let Ok(config) = load_from(&path) {
-                return config;
-            }
-        }
+    // 2. 共通フォールバック（埋め込み）
+    if let Ok(config) = toml::from_str(DEFAULT_CONFIG) {
+        return config;
     }
 
-    // フォールバック: 最小限のデフォルト
+    // 3. 最小限のフォールバック（通常はここに到達しない）
     Config {
         search: default_search_engines(),
         folders: IndexMap::new(),

--- a/muhenkan-switch/src/kanata.rs
+++ b/muhenkan-switch/src/kanata.rs
@@ -164,9 +164,8 @@ impl KanataManager {
     /// kanata バイナリのパスを取得
     ///
     /// 探索順序:
-    /// 1. exe と同じディレクトリ（インストール環境）
-    /// 2. カレントディレクトリ（開発環境: mise run gui 時）
-    /// 3. ワークスペースルート（開発環境: CARGO_MANIFEST_DIR の親）
+    /// 1. exe と同じディレクトリ（インストール環境 / dev: ./bin/ 実行時）
+    /// 2. CARGO_MANIFEST_DIR/../bin/（開発環境: cargo run 互換）
     fn kanata_path() -> Result<PathBuf> {
         let name = kanata_binary_name();
 
@@ -178,20 +177,12 @@ impl KanataManager {
             }
         }
 
-        // 2. カレントディレクトリ
-        let cwd_path = PathBuf::from(name);
-        if cwd_path.exists() {
-            return Ok(std::env::current_dir()
-                .unwrap_or_default()
-                .join(name));
-        }
-
-        // 3. ワークスペースルート（開発環境）
-        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        // 2. ワークスペースルートの bin/（開発環境）
+        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .map(|p| p.to_path_buf());
-        if let Some(ref root) = workspace_root {
-            let path = root.join(name);
+            .map(|p| p.join("bin"));
+        if let Some(ref dir) = bin_dir {
+            let path = dir.join(name);
             if path.exists() {
                 return Ok(path);
             }
@@ -206,9 +197,8 @@ impl KanataManager {
     /// kanata 設定ファイルのパスを取得
     ///
     /// 探索順序:
-    /// 1. exe と同じディレクトリの muhenkan.kbd（インストール環境）
-    /// 2. cwd の kanata/muhenkan.kbd（開発環境）
-    /// 3. ワークスペースルートの kanata/muhenkan.kbd（開発環境）
+    /// 1. exe と同じディレクトリの muhenkan.kbd（インストール環境 / dev: ./bin/ 実行時）
+    /// 2. CARGO_MANIFEST_DIR/../bin/muhenkan.kbd（開発環境: cargo run 互換）
     fn kbd_path() -> Result<PathBuf> {
         // 1. exe と同じディレクトリ
         if let Ok(exe_dir) = std::env::current_exe().map(|p| p.parent().unwrap().to_path_buf()) {
@@ -218,21 +208,12 @@ impl KanataManager {
             }
         }
 
-        // 2. カレントディレクトリの kanata/ サブディレクトリ
-        let cwd_path = PathBuf::from("kanata").join("muhenkan.kbd");
-        if cwd_path.exists() {
-            return Ok(std::env::current_dir()
-                .unwrap_or_default()
-                .join("kanata")
-                .join("muhenkan.kbd"));
-        }
-
-        // 3. ワークスペースルート（開発環境）
-        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        // 2. ワークスペースルートの bin/（開発環境）
+        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .map(|p| p.to_path_buf());
-        if let Some(ref root) = workspace_root {
-            let path = root.join("kanata").join("muhenkan.kbd");
+            .map(|p| p.join("bin"));
+        if let Some(ref dir) = bin_dir {
+            let path = dir.join("muhenkan.kbd");
             if path.exists() {
                 return Ok(path);
             }
@@ -247,10 +228,8 @@ impl KanataManager {
     /// muhenkan-switch-core バイナリが存在するディレクトリを取得
     ///
     /// 探索順序:
-    /// 1. exe と同じディレクトリ（インストール環境）
-    /// 2. カレントディレクトリの bin/（開発環境: mise run build 後）
-    /// 3. ワークスペースルートの bin/（開発環境）
-    /// 4. target/debug/（開発環境: cargo build 直後）
+    /// 1. exe と同じディレクトリ（インストール環境 / dev: ./bin/ 実行時）
+    /// 2. CARGO_MANIFEST_DIR/../bin/（開発環境: cargo run 互換）
     fn core_binary_dir() -> Result<PathBuf> {
         let name = core_binary_name();
 
@@ -261,30 +240,13 @@ impl KanataManager {
             }
         }
 
-        // 2. カレントディレクトリの bin/
-        if let Ok(cwd) = std::env::current_dir() {
-            let bin_dir = cwd.join("bin");
-            if bin_dir.join(name).exists() {
-                return Ok(bin_dir);
-            }
-        }
-
-        // 3. ワークスペースルートの bin/
-        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        // 2. ワークスペースルートの bin/（開発環境）
+        let bin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .map(|p| p.to_path_buf());
-        if let Some(ref root) = workspace_root {
-            let bin_dir = root.join("bin");
-            if bin_dir.join(name).exists() {
-                return Ok(bin_dir);
-            }
-        }
-
-        // 4. target/debug/（開発環境）
-        if let Some(ref root) = workspace_root {
-            let debug_dir = root.join("target").join("debug");
-            if debug_dir.join(name).exists() {
-                return Ok(debug_dir);
+            .map(|p| p.join("bin"));
+        if let Some(ref dir) = bin_dir {
+            if dir.join(name).exists() {
+                return Ok(dir.clone());
             }
         }
 


### PR DESCRIPTION
## 問題

インストール済み環境の初回起動時に `apps`/`folders`/`searches` が全て空の
最小限 `config.toml` が生成されていた。

### 原因

`default_config()` が `env!(\"CARGO_MANIFEST_DIR\")` でビルド環境のパスを参照していたため、
インストール済み環境ではパスが存在せず、最小フォールバック設定が使用されていた。

### 症状

- タイムスタンプ操作（X/C/V）: **正常動作**（ハードコード処理）
- アプリ切り替え（A/F/T等）: **動作しない**（config.toml 依存）
- フォルダ（1〜5）: **動作しない**（config.toml 依存）
- Web検索（Q/W/R/G/B）: **動作しない**（config.toml 依存）

## 修正

`include_str!()` で `config/default-{os}.toml` をコンパイル時にバイナリへ埋め込む。
インストール環境でも `env!(\"CARGO_MANIFEST_DIR\")` に依存せず、OS に適したデフォルト設定で
`config.toml` を生成できるようになる。

## 暫定対処（修正版リリース前）

インストール済みの方は以下の手順で手動対処可能:

1. `%LOCALAPPDATA%\muhenkan-switch\` を開く
2. `config.toml` を削除
3. 代わりにリポジトリの `config/default-windows.toml` の内容をコピーして `config.toml` として保存
4. トレイから Stop → Start でkanata を再起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)