### PR TITLE
fix: ヘルプ・トレイメニューのクロスプラットフォーム対応

### DIFF
--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -74,12 +74,18 @@
 
     <section>
       <h2>更新方法</h2>
-      <p>インストール先フォルダの更新スクリプトを実行してください。<br>最新版のダウンロードとインストールが自動で行われます。</p>
+      <p><strong>インストーラーで導入した場合:</strong><br>
+        <a href="https://github.com/kimushun1101/muhenkan-switch-rs/releases" style="color:#89b4fa;">GitHub Releases</a> から最新版をダウンロードし、再インストールしてください。</p>
+      <p><strong>スクリプトで導入した場合:</strong><br>
+        インストール先フォルダの更新スクリプトを実行してください。最新版のダウンロードとインストールが自動で行われます。</p>
     </section>
 
     <section>
       <h2>アンインストール</h2>
-      <p>インストール先フォルダのアンインストールスクリプトを実行してください。</p>
+      <p><strong>インストーラーで導入した場合:</strong><br>
+        「設定  &gt; アプリ &gt; インストールされているアプリ」から muhenkan-switch を削除してください。</p>
+      <p><strong>スクリプトで導入した場合:</strong><br>
+        インストール先フォルダのアンインストールスクリプトを実行してください。</p>
     </section>
   </div>
 </body>

--- a/muhenkan-switch/src/tray.rs
+++ b/muhenkan-switch/src/tray.rs
@@ -29,8 +29,6 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let sep1 = PredefinedMenuItem::separator(handle)?;
     let settings_item =
         MenuItemBuilder::with_id("settings", "設定...").build(handle)?;
-    let open_config_item =
-        MenuItemBuilder::with_id("open_config", "config.toml を開く").build(handle)?;
     let open_dir_item = MenuItemBuilder::with_id("open_dir", "インストール先を開く")
         .build(handle)?;
     let sep2 = PredefinedMenuItem::separator(handle)?;
@@ -47,7 +45,6 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         .item(&restart_item)
         .item(&sep1)
         .item(&settings_item)
-        .item(&open_config_item)
         .item(&open_dir_item)
         .item(&sep2)
         .item(&autostart_item)
@@ -79,9 +76,6 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                         let _ = window.show();
                         let _ = window.set_focus();
                     }
-                }
-                "open_config" => {
-                    let _ = crate::commands::open_config_in_editor();
                 }
                 "open_dir" => {
                     let _ = crate::commands::open_install_dir();


### PR DESCRIPTION
## Summary
- トレイメニューから「config.toml を開く」を削除（GUI 設定で完結するため不要）
- ヘルプページの更新方法・アンインストール手順をインストーラー/スクリプト両対応に変更

## 変更ファイル
- `muhenkan-switch/src/tray.rs` — config.toml メニュー項目を削除
- `muhenkan-switch/frontend/help.html` — 更新・アンインストール手順を両対応に

## Test plan
- [ ] `cargo build -p muhenkan-switch-config -p muhenkan-switch-core` でビルド確認
- [ ] help.html をブラウザで開いて表示確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)