### PR TITLE
fix: mise run build で GUI バイナリがビルドされない問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 # Generated files
 /muhenkan-switch/gen/
 /muhenkan-switch/muhenkan-switch
+/muhenkan-switch/binaries/
 
 # Test install staging
 /tmp-test-install/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.3.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.3.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.3.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/mise.toml
+++ b/mise.toml
@@ -173,11 +173,26 @@ else:
 
 [tasks.build]
 description = "Build workspace (debug)"
-depends = ["check-deps"]
+depends = ["check-deps", "fetch-kanata"]
 shell = "bash -c"
 run = """
-cargo build --workspace
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
+TRIPLE=$(rustc -vV | grep host | awk '{print $2}')
+
+# ── Tauri externalBin の準備 ──
+# muhenkan-switch-core を先にビルドして binaries/ に配置
+cargo build -p muhenkan-switch-core
+mkdir -p muhenkan-switch/binaries
+cp "target/debug/muhenkan-switch-core${EXT}" "muhenkan-switch/binaries/muhenkan-switch-core-${TRIPLE}${EXT}"
+echo "[build] Prepared externalBin: muhenkan-switch-core-${TRIPLE}${EXT}"
+
+# kanata バイナリを binaries/ に配置
+cp "./bin/kanata_cmd_allowed${EXT}" "muhenkan-switch/binaries/kanata_cmd_allowed-${TRIPLE}${EXT}"
+echo "[build] Prepared externalBin: kanata_cmd_allowed-${TRIPLE}${EXT}"
+
+# ── ワークスペース全体をビルド ──
+cargo build --workspace
+
 # Linux ではバイナリ名と crate ディレクトリ名が衝突するため bin/ にコピー
 mkdir -p ./bin
 cp "target/debug/muhenkan-switch-core${EXT}" "./bin/muhenkan-switch-core${EXT}"
@@ -207,17 +222,30 @@ fi
 
 [tasks.release]
 description = "Build workspace (release)"
-depends = ["check-deps"]
+depends = ["check-deps", "fetch-kanata"]
 shell = "bash -c"
 run = """
-cargo build --workspace --release
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
+TRIPLE=$(rustc -vV | grep host | awk '{print $2}')
+
+# ── Tauri externalBin の準備 ──
+cargo build -p muhenkan-switch-core --release
+mkdir -p muhenkan-switch/binaries
+cp "target/release/muhenkan-switch-core${EXT}" "muhenkan-switch/binaries/muhenkan-switch-core-${TRIPLE}${EXT}"
+echo "[release] Prepared externalBin: muhenkan-switch-core-${TRIPLE}${EXT}"
+
+cp "./bin/kanata_cmd_allowed${EXT}" "muhenkan-switch/binaries/kanata_cmd_allowed-${TRIPLE}${EXT}"
+echo "[release] Prepared externalBin: kanata_cmd_allowed-${TRIPLE}${EXT}"
+
+# ── ワークスペース全体をビルド ──
+cargo build --workspace --release
+
 mkdir -p ./bin
 cp "target/release/muhenkan-switch-core${EXT}" "./bin/muhenkan-switch-core${EXT}"
-echo "[dev] Copied -> ./bin/muhenkan-switch-core${EXT}"
+echo "[release] Copied -> ./bin/muhenkan-switch-core${EXT}"
 if [ -f "target/release/muhenkan-switch${EXT}" ]; then
   cp "target/release/muhenkan-switch${EXT}" "./bin/muhenkan-switch${EXT}"
-  echo "[dev] Copied -> ./bin/muhenkan-switch${EXT}"
+  echo "[release] Copied -> ./bin/muhenkan-switch${EXT}"
 fi
 """
 


### PR DESCRIPTION
## Summary
- `cargo build --workspace` の前に Tauri `externalBin` が要求する `muhenkan-switch-core` と `kanata_cmd_allowed` を `muhenkan-switch/binaries/` に配置するステップを追加
- `build` / `release` 両タスクに `fetch-kanata` 依存を追加し、kanata バイナリの存在を保証
- `muhenkan-switch/binaries/` を `.gitignore` に追加

## Test plan
- [x] `mise run build` でエラーなくビルド完了
- [x] `bin/muhenkan-switch.exe` が生成される
- [x] `muhenkan-switch/binaries/` が git でトラッキングされない

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)