### PR TITLE
fix: ヘルプ画面のリンク色を改善

### DIFF
--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -31,6 +31,8 @@
     ol { padding-left: 20px; }
     ol li { margin-bottom: 4px; }
     code { font-family: "Cascadia Code", "Consolas", monospace; font-size: 12px; color: #8888aa; }
+    a { color: #74c7ec; }
+    a:hover { color: #89dceb; }
   </style>
 </head>
 <body>
@@ -75,7 +77,7 @@
     <section>
       <h2>更新方法</h2>
       <p><strong>インストーラーで導入した場合:</strong><br>
-        <a href="https://github.com/kimushun1101/muhenkan-switch-rs/releases" style="color:#89b4fa;">GitHub Releases</a> から最新版をダウンロードし、再インストールしてください。</p>
+        <a href="https://github.com/kimushun1101/muhenkan-switch-rs/releases">GitHub Releases</a> から最新版をダウンロードし、再インストールしてください。</p>
       <p><strong>スクリプトで導入した場合:</strong><br>
         インストール先フォルダの更新スクリプトを実行してください。最新版のダウンロードとインストールが自動で行われます。</p>
     </section>


### PR DESCRIPTION
## Summary
- ヘルプ画面の GitHub Releases リンクが暗い背景色と被って見えづらかった問題を修正
- インラインスタイルを削除し `<style>` ブロックでリンク色を一括定義
- `#89b4fa` (blue) → `#74c7ec` (sapphire) でコントラスト改善

## 更新・アンインストールのワンライナー対応について

ヘルプ画面の更新・アンインストール手順をワンライナーコマンドで実行可能にする案を検討した。
現状のスクリプト (`update.ps1` / `uninstall.ps1` 等) は既にインストール先パスをハードコードしており、リモートから直接実行する構成的な変更はほぼ不要。

ただし **#42 (tauri-plugin-updater による自動更新)** を先に実装すべきと判断し、本 PR ではリンク色の修正のみに留める。

**理由:**
- #42 完了後、インストーラー経由のユーザーは GUI 内で自動更新可能になる
- #42 のステップ5で zip + スクリプト版の廃止を検討しており、今ワンライナー対応を作り込んでも将来不要になる可能性が高い
- Linux/macOS 向けスクリプトの要否も #42 の結果次第

## Test plan
- [ ] `mise run build` が成功すること
- [ ] ヘルプ画面でリンクが背景と区別できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)