### PR TITLE
chore: バージョンを 0.5.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch-rs"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend"


### PR DESCRIPTION
## Summary
- workspace Cargo.toml + tauri.conf.json のバージョンを 0.4.2 → 0.5.0 に更新
- tauri-plugin-updater 導入に伴うマイナーバージョンアップ

## Test plan
- [x] `cargo check` ビルド成功
- [ ] マージ後 `git tag v0.5.0 && git push origin v0.5.0` でリリース

🤖 Generated with [Claude Code](https://claude.com/claude-code)