### PR TITLE
fix: NSIS リソース配置修正 + MSI ビルド削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           name: release-${{ matrix.asset_suffix }}
           path: muhenkan-switch-rs-${{ matrix.asset_suffix }}.*
 
-  build-windows-msi:
+  build-windows-nsis:
     runs-on: windows-latest
 
     steps:
@@ -147,9 +147,9 @@ jobs:
           if (-not $binaryFile) { Write-Error "kanata binary not found: $binaryName"; exit 1 }
           Copy-Item $binaryFile.FullName "muhenkan-switch/binaries/kanata_cmd_allowed-x86_64-pc-windows-msvc.exe"
 
-      # 4. cargo tauri build で .msi / NSIS .exe を生成（署名付き updater artifacts を含む）
-      - name: Build Windows installer (.msi and NSIS)
-        run: npx --yes @tauri-apps/cli@2 build --target x86_64-pc-windows-msvc --bundles msi,nsis
+      # 4. cargo tauri build で NSIS .exe を生成（署名付き updater artifacts を含む）
+      - name: Build Windows installer (NSIS)
+        run: npx --yes @tauri-apps/cli@2 build --target x86_64-pc-windows-msvc --bundles nsis
         working-directory: muhenkan-switch
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -157,15 +157,13 @@ jobs:
 
       # 5. 生成されたインストーラーを artifacts にアップロード
       #    Cargo ワークスペースの target/ はルートに置かれるため muhenkan-switch/ プレフィックスは不要
-      - name: Upload MSI artifact
+      - name: Upload NSIS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-windows-msi
+          name: release-windows-nsis
           path: |
-            target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
-            target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi.sig
-            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
-            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe.sig
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe.sig
 
       # 6. Power User 向け zip もビルド・パッケージ
       - name: Package zip release (Power User)
@@ -199,7 +197,7 @@ jobs:
           path: muhenkan-switch-rs-windows-x64.*
 
   release:
-    needs: [build, build-windows-msi]
+    needs: [build, build-windows-nsis]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -235,17 +233,14 @@ jobs:
           files: |
             muhenkan-switch-rs-*.tar.gz
             muhenkan-switch-rs-*.zip
-            msi/*.msi
-            msi/*.msi.sig
             nsis/*-setup.exe
-            nsis/*-setup.exe.sig
             latest.json
           body: |
             ## muhenkan-switch-rs
 
             ### Windows インストール（推奨）
 
-            1. 下記から `muhenkan-switch_x64.msi`（または `_x64-setup.exe`）をダウンロード
+            1. 下記から `muhenkan-switch_x64-setup.exe` をダウンロード
             2. ダブルクリックしてインストール
             3. スタートメニューから muhenkan-switch を起動
 
@@ -262,7 +257,7 @@ jobs:
             ```
 
             ### ダウンロード
-            - **Windows (x64) インストーラー**: `muhenkan-switch_x64.msi` / `muhenkan-switch_x64-setup.exe`
+            - **Windows (x64) インストーラー**: `muhenkan-switch_x64-setup.exe`
             - **Windows (x64) zip（上級者向け）**: `muhenkan-switch-rs-windows-x64.zip`
             - **Linux (x64)**: `muhenkan-switch-rs-linux-x64.tar.gz`
             - **macOS (x64)**: `muhenkan-switch-rs-macos-x64.tar.gz` ⚠️ 未検証

--- a/docs/ui-references.md
+++ b/docs/ui-references.md
@@ -48,6 +48,13 @@
 - **Universal Binary 要件** — Intel (x86_64) + Apple Silicon (aarch64) の両方をサポートするには、sidecar も含めて universal binary 化（lipo）が必要
 - **設定ファイルの永続化** — .app バンドル内は読み取り専用。config.toml 等は `~/Library/Application Support/` に移す再設計が必要
 
+### MSI をやめて NSIS のみにした理由
+
+- **未署名 MSI はポリシーでブロックされる** — Windows のグループポリシーにより「システム管理者によって、ポリシーはこのインストールを実行できないように設定されています」と表示され、インストールできない環境がある
+- **署名にはコード署名証明書が必要** — OV 証明書で $70〜200/年、EV 証明書で $200〜500/年。OSS 向け無料の [SignPath.io](https://signpath.io/) もあるが審査が必要
+- **MSI が好まれるのは企業一括配布（SCCM/Intune）だが、その場合も署名済みが前提** — 未署名 MSI を配布するメリットはほぼない
+- **NSIS はポリシー制限を受けにくい** — SmartScreen 警告は出るが、「詳細情報」→「実行」で通る
+
 ### 参考リンク
 
 - [Tauri v2 AppImage docs](https://v2.tauri.app/distribute/appimage/)

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -37,12 +37,11 @@
       "binaries/kanata_cmd_allowed",
       "binaries/muhenkan-switch-core"
     ],
-    "resources": ["../kanata/muhenkan.kbd"],
+    "resources": {
+      "../kanata/muhenkan.kbd": "muhenkan.kbd"
+    },
     "licenseFile": "../LICENSE",
     "windows": {
-      "wix": {
-        "language": ["ja-JP"]
-      },
       "nsis": {
         "languages": ["Japanese"]
       }


### PR DESCRIPTION
## Summary
- `resources` を配列形式からオブジェクト形式に戻し、`muhenkan.kbd` がインストール先ルートに配置されるよう修正
- 未署名 MSI はポリシーでブロックされるため、NSIS のみに変更
- リリースアセットから `.msi` / `.sig` を削除

## 原因
配列形式 `["../kanata/muhenkan.kbd"]` では相対パスが保持され、`_up_/kanata/muhenkan.kbd` に配置されていた。
アプリは `exe_dir/muhenkan.kbd` を探すため見つからず、kanata が起動できなかった。

## 修正
オブジェクト形式 `{"../kanata/muhenkan.kbd": "muhenkan.kbd"}` に変更し、ファイル名のみで配置。

## Test plan
- [ ] マージ後にタグ push → リリースワークフロー成功
- [ ] NSIS インストーラーでインストール後、kanata が正常に起動すること
- [ ] `muhenkan.kbd` がインストール先ルートに配置されていること

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)