### PR TITLE
fix: リリースアセットの setup.exe パターンを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
           files: |
             muhenkan-switch-rs-*.tar.gz
             muhenkan-switch-rs-*.zip
-            nsis/*-setup.exe
+            *-setup.exe
             latest.json
           body: |
             ## muhenkan-switch-rs


### PR DESCRIPTION
## Summary
- リリースアセットのパターン `nsis/*-setup.exe` → `*-setup.exe` に修正

## 原因
`upload-artifact` で同一ディレクトリ内のファイルのみアップロードした場合、ディレクトリ構造が保持されない。`download-artifact` 後にファイルがルート直下に配置されるため、`nsis/` プレフィックス付きパターンではマッチしなかった。

## Test plan
- [ ] マージ後にタグ push → setup.exe がリリースアセットに含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)