### PR TITLE
feat: インストール方法の判別によるUI出し分け

### DIFF
--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -74,20 +74,28 @@
 
     <section>
       <h2>更新方法</h2>
-      <p><strong>インストーラーで導入した場合（Windows）:</strong><br>
+      <p data-install="installer">
         起動時に自動でアップデートを確認します。新しいバージョンがある場合は通知が表示され、ワンクリックで更新できます。<br>
         トレイアイコンの「アップデートを確認...」から手動で確認することもできます。</p>
-      <p><strong>スクリプトで導入した場合:</strong><br>
+      <p data-install="script">
         インストール先フォルダの更新スクリプトを実行してください。最新版のダウンロードとインストールが自動で行われます。</p>
     </section>
 
     <section>
       <h2>アンインストール</h2>
-      <p><strong>インストーラーで導入した場合:</strong><br>
+      <p data-install="installer">
         「設定  &gt; アプリ &gt; インストールされているアプリ」から muhenkan-switch を削除してください。</p>
-      <p><strong>スクリプトで導入した場合:</strong><br>
+      <p data-install="script">
         インストール先フォルダのアンインストールスクリプトを実行してください。</p>
     </section>
   </div>
+  <script>
+    const install = new URLSearchParams(location.search).get("install");
+    if (install) {
+      document.querySelectorAll("[data-install]").forEach(el => {
+        if (el.dataset.install !== install) el.style.display = "none";
+      });
+    }
+  </script>
 </body>
 </html>

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -568,11 +568,15 @@ async function init() {
     console.error("バージョン情報の取得に失敗:", e);
   }
 
-  // 起動 5 秒後にサイレントチェック
-  setTimeout(() => checkForUpdate(true), 5000);
+  // インストーラー版のみ自動更新チェック
+  const installType = await invoke("get_install_type");
+  if (installType === "installer") {
+    // 起動 5 秒後にサイレントチェック
+    setTimeout(() => checkForUpdate(true), 5000);
 
-  // トレイメニューからの手動チェック
-  listen("check-update-requested", () => checkForUpdate(false));
+    // トレイメニューからの手動チェック
+    listen("check-update-requested", () => checkForUpdate(false));
+  }
 }
 
 init();

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -269,6 +269,29 @@ pub fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(),
     }
 }
 
+// ── Install type detection ──
+
+/// Returns true if this is an NSIS installer install (no update.bat next to exe).
+pub fn is_nsis_install() -> bool {
+    if !cfg!(target_os = "windows") {
+        return false;
+    }
+    let has_update_bat = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join("update.bat").exists()))
+        .unwrap_or(false);
+    !has_update_bat
+}
+
+#[tauri::command]
+pub fn get_install_type() -> String {
+    if is_nsis_install() {
+        "installer".to_string()
+    } else {
+        "script".to_string()
+    }
+}
+
 // ── Utility commands ──
 
 #[tauri::command]
@@ -322,9 +345,11 @@ pub fn open_help_window(app: tauri::AppHandle) -> Result<(), String> {
     }
     // Window creation dispatches to the main thread via run_on_main_thread().
     // Spawn a thread so the invoke() returns immediately and IPC stays responsive.
+    let install_type = get_install_type();
     std::thread::spawn(move || {
         use tauri::{WebviewUrl, WebviewWindowBuilder};
-        let _ = WebviewWindowBuilder::new(&app, "help", WebviewUrl::App("help.html".into()))
+        let url = format!("help.html?install={}", install_type);
+        let _ = WebviewWindowBuilder::new(&app, "help", WebviewUrl::App(url.into()))
             .title("使い方 — muhenkan-switch")
             .inner_size(600.0, 700.0)
             .resizable(true)

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
             commands::validate_timestamp_format,
             commands::check_update,
             commands::install_update,
+            commands::get_install_type,
         ])
         .setup(|app| {
             // 初回起動時: exe 同梱ディレクトリに config.toml がなければデフォルト設定を生成

--- a/muhenkan-switch/src/tray.rs
+++ b/muhenkan-switch/src/tray.rs
@@ -31,8 +31,12 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         MenuItemBuilder::with_id("settings", "設定...").build(handle)?;
     let open_dir_item = MenuItemBuilder::with_id("open_dir", "インストール先を開く")
         .build(handle)?;
-    let check_update_item =
-        MenuItemBuilder::with_id("check_update", "アップデートを確認...").build(handle)?;
+    let is_installer = crate::commands::is_nsis_install();
+    let check_update_item = if is_installer {
+        Some(MenuItemBuilder::with_id("check_update", "アップデートを確認...").build(handle)?)
+    } else {
+        None
+    };
     let sep2 = PredefinedMenuItem::separator(handle)?;
     let autostart_item =
         CheckMenuItemBuilder::with_id("autostart", "ログイン時に自動起動")
@@ -40,15 +44,18 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let sep3 = PredefinedMenuItem::separator(handle)?;
     let quit_item = MenuItemBuilder::with_id("quit", "終了").build(handle)?;
 
-    let menu = MenuBuilder::new(handle)
+    let mut menu = MenuBuilder::new(handle)
         .item(&status_item)
         .item(&start_item)
         .item(&stop_item)
         .item(&restart_item)
         .item(&sep1)
         .item(&settings_item)
-        .item(&open_dir_item)
-        .item(&check_update_item)
+        .item(&open_dir_item);
+    if let Some(ref item) = check_update_item {
+        menu = menu.item(item);
+    }
+    let menu = menu
         .item(&sep2)
         .item(&autostart_item)
         .item(&sep3)


### PR DESCRIPTION
## Summary
- `update.bat` の有無でインストーラー版（NSIS）/ スクリプト版（zip）を判別する `is_nsis_install()` と `get_install_type` コマンドを追加
- スクリプト版ではトレイメニューの「アップデートを確認...」を非表示にし、起動時の自動更新チェックもスキップ
- ヘルプ画面（`help.html`）でインストール方法に応じた更新・アンインストール説明のみ表示

## Test plan
- [ ] `mise run build && mise run dev` で起動（`bin/update.bat` なし）→ インストーラー版として動作確認
  - トレイに「アップデートを確認...」が表示される
  - ヘルプにインストーラー版の説明のみ表示
- [ ] `bin/update.bat` を手動配置して再起動 → スクリプト版として動作確認
  - トレイに「アップデートを確認...」が表示されない
  - ヘルプにスクリプト版の説明のみ表示

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)