### PR TITLE
fix: updater の panic でアプリが落ちないよう対策

### DIFF
--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -221,31 +221,45 @@ pub struct UpdateInfo {
 
 #[tauri::command]
 pub async fn check_update(app: tauri::AppHandle) -> Result<Option<UpdateInfo>, String> {
-    use tauri_plugin_updater::UpdaterExt;
-    match app.updater().map_err(|e| format!("{:#}", e))?.check().await {
-        Ok(Some(update)) => Ok(Some(UpdateInfo {
-            version: update.version.clone(),
-            body: update.body.clone(),
-        })),
-        Ok(None) => Ok(None),
-        Err(e) => Err(format!("{:#}", e)),
-    }
+    // spawn で隔離し、updater 内部の panic でアプリが落ちるのを防ぐ
+    tauri::async_runtime::spawn(async move {
+        use tauri_plugin_updater::UpdaterExt;
+        let update = app
+            .updater()
+            .map_err(|e| format!("{:#}", e))?
+            .check()
+            .await
+            .map_err(|e| format!("{:#}", e))?;
+        match update {
+            Some(u) => Ok(Some(UpdateInfo {
+                version: u.version.clone(),
+                body: u.body.clone(),
+            })),
+            None => Ok(None),
+        }
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("アップデート確認中にエラーが発生しました: {}", e)))
 }
 
 #[tauri::command]
 pub async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri_plugin_updater::UpdaterExt;
-    let update = app
-        .updater()
-        .map_err(|e| format!("{:#}", e))?
-        .check()
-        .await
-        .map_err(|e| format!("{:#}", e))?
-        .ok_or("アップデートが見つかりません".to_string())?;
-    update
-        .download_and_install(|_, _| {}, || {})
-        .await
-        .map_err(|e| format!("{:#}", e))
+    tauri::async_runtime::spawn(async move {
+        use tauri_plugin_updater::UpdaterExt;
+        let update = app
+            .updater()
+            .map_err(|e| format!("{:#}", e))?
+            .check()
+            .await
+            .map_err(|e| format!("{:#}", e))?
+            .ok_or("アップデートが見つかりません".to_string())?;
+        update
+            .download_and_install(|_, _| {}, || {})
+            .await
+            .map_err(|e| format!("{:#}", e))
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("アップデートインストール中にエラーが発生しました: {}", e)))
 }
 
 // ── Autostart ──

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -5,6 +5,26 @@ mod kanata;
 mod tray;
 
 fn main() {
+    // windows_subsystem = "windows" では stderr が見えないため、パニック時にファイルへ記録
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(log_path) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join("panic.log")))
+        {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(log_path)
+            {
+                use std::io::Write;
+                let _ = writeln!(f, "{}", info);
+                let _ = writeln!(f, "{}", std::backtrace::Backtrace::force_capture());
+            }
+        }
+        default_hook(info);
+    }));
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
## Summary
- panic hook を追加し、`windows_subsystem = "windows"` で見えない panic を exe 隣の `panic.log` に記録
- `check_update` / `install_update` を `tauri::async_runtime::spawn` で隔離し、updater 内部の panic でアプリが落ちないように変更

## Test plan
- [ ] `mise run build && mise run dev` で起動し、アップデート確認でアプリが落ちないことを確認
- [ ] panic 発生時に `panic.log` が生成されることを確認

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)