### PR TITLE
fix: 旧バージョンが生成した不完全な config.toml を起動時に再生成

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -478,6 +478,20 @@ mod tests {
         assert_eq!(config.timestamp.format, "%Y%m%d");
         assert_eq!(config.timestamp.position, "before");
         assert!(config.search.contains_key("google"));
+        // OS 別デフォルトが正しくパースされ、全セクションが埋まっていること
+        assert!(
+            config.search.len() >= 5,
+            "Expected at least 5 search engines, got {}",
+            config.search.len()
+        );
+        assert!(
+            !config.folders.is_empty(),
+            "Expected non-empty folders, got empty"
+        );
+        assert!(
+            !config.apps.is_empty(),
+            "Expected non-empty apps, got empty"
+        );
     }
 
     #[test]

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -60,11 +60,20 @@ fn main() {
             commands::get_install_type,
         ])
         .setup(|app| {
-            // 初回起動時: exe 同梱ディレクトリに config.toml がなければデフォルト設定を生成
+            // 初回起動時 or 壊れた config.toml の再生成
             if let Ok(exe_path) = std::env::current_exe() {
                 if let Some(exe_dir) = exe_path.parent() {
                     let config_path = exe_dir.join("config.toml");
-                    if !config_path.exists() {
+                    let should_generate = if config_path.exists() {
+                        // 旧バージョンが生成した不完全な config.toml を検出して再生成
+                        match muhenkan_switch_config::load_from(&config_path) {
+                            Ok(cfg) => cfg.folders.is_empty() && cfg.apps.is_empty(),
+                            Err(_) => true,
+                        }
+                    } else {
+                        true
+                    };
+                    if should_generate {
                         let default = muhenkan_switch_config::default_config();
                         if let Err(e) = muhenkan_switch_config::save(&config_path, &default) {
                             eprintln!("[setup] config.toml の生成に失敗: {:#}", e);


### PR DESCRIPTION
## Summary
- 起動時に `config.toml` の folders/apps が両方空の場合、壊れた設定と判定して埋め込みデフォルトから再生成するようにした
- `include_str!` 導入前（`34ec0ff` 以前）に生成された不完全な config.toml が NSIS 再インストール後も残り続ける問題を修正
- `test_default_config` テストを強化し、全セクション（search/folders/apps）が埋まっていることを検証

## Root Cause
`34ec0ff` 以前のバージョンでは `default_config()` がランタイムで設定ファイルを読み込もうとしていたが、インストール環境では `CARGO_MANIFEST_DIR` が存在せず minimal fallback（Google のみ）に落ちていた。この壊れた config.toml は NSIS アンインストーラーでは削除されないため、再インストール後も残り続けていた。

## Test plan
- [x] `cargo test -p muhenkan-switch-config --release` — 24 tests passed
- [x] `mise run build` + 壊れた config.toml を配置 → `./bin/muhenkan-switch.exe` 起動で全セクション復元を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)