### PR TITLE
feat: NSIS アンインストール時に設定ファイル削除の確認ダイアログを追加

### DIFF
--- a/muhenkan-switch/nsis/hooks.nsh
+++ b/muhenkan-switch/nsis/hooks.nsh
@@ -1,0 +1,11 @@
+; アンインストール後: 設定ファイルの削除を確認
+!macro NSIS_HOOK_POSTUNINSTALL
+  MessageBox MB_YESNO "設定ファイルを削除しますか？$\n$\n残す場合はフォルダを開きます。$\n$INSTDIR" IDYES _delete_config
+    ; 「いいえ」— フォルダを開く
+    ExecShell "open" "$INSTDIR"
+    Goto _done_config
+  _delete_config:
+    ; 「はい」— ディレクトリごと削除
+    RMDir /r "$INSTDIR"
+  _done_config:
+!macroend

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -43,7 +43,8 @@
     "licenseFile": "../LICENSE",
     "windows": {
       "nsis": {
-        "languages": ["Japanese"]
+        "languages": ["Japanese"],
+        "installerHooks": "./nsis/hooks.nsh"
       }
     }
   },


### PR DESCRIPTION
## Summary
- アンインストール完了後に「設定ファイルを削除しますか？」ダイアログを表示
- 「はい」→ インストールディレクトリごと自動削除
- 「いいえ」→ フォルダをエクスプローラーで開き、手動削除を促す
- NSIS の `installerHooks` 機能で `NSIS_HOOK_POSTUNINSTALL` を使用

## Background
NSIS アンインストーラーはインストーラーが配置したファイルのみ削除するため、アプリが実行時に生成した `config.toml` 等がインストールディレクトリに残り続けていた。

## Test plan
- [x] ローカルで `tauri build --bundles nsis` → インストール → アンインストールで動作確認済み
  - 「はい」選択時: ディレクトリごと削除される
  - 「いいえ」選択時: フォルダが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)