### PR TITLE
feat: 設定のエクスポート/インポート機能を追加

### DIFF
--- a/muhenkan-switch/Cargo.toml
+++ b/muhenkan-switch/Cargo.toml
@@ -20,6 +20,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-store = "2"
 tauri-plugin-updater = "2"
 shared_child = "1"
+dirs = "6.0.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/muhenkan-switch/capabilities/default.json
+++ b/muhenkan-switch/capabilities/default.json
@@ -6,6 +6,7 @@
     "core:default",
     "shell:allow-open",
     "dialog:allow-open",
+    "dialog:allow-save",
     "store:default",
     "autostart:default",
     "updater:default"

--- a/muhenkan-switch/capabilities/default.json
+++ b/muhenkan-switch/capabilities/default.json
@@ -7,6 +7,8 @@
     "shell:allow-open",
     "dialog:allow-open",
     "dialog:allow-save",
+    "dialog:allow-message",
+    "dialog:allow-ask",
     "store:default",
     "autostart:default",
     "updater:default"

--- a/muhenkan-switch/frontend/index.html
+++ b/muhenkan-switch/frontend/index.html
@@ -46,6 +46,14 @@
         </fieldset>
 
         <fieldset>
+          <legend>設定管理</legend>
+          <div class="button-row">
+            <button id="btn-export-config">エクスポート</button>
+            <button id="btn-import-config">インポート</button>
+          </div>
+        </fieldset>
+
+        <fieldset>
           <legend>ヘルプ</legend>
           <div class="button-row">
             <button id="btn-help">使い方</button>

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -492,10 +492,7 @@ document.getElementById("btn-export-config").addEventListener("click", async () 
   try {
     const exported = await invoke("export_config");
     if (exported) {
-      const btn = document.getElementById("btn-export-config");
-      const orig = btn.textContent;
-      btn.textContent = "エクスポートしました";
-      setTimeout(() => { btn.textContent = orig; }, 1500);
+      alert("設定ファイルをエクスポートしました。");
     }
   } catch (e) {
     alert("エクスポートに失敗しました:\n" + e);
@@ -509,10 +506,7 @@ document.getElementById("btn-import-config").addEventListener("click", async () 
     if (newConfig) {
       config = newConfig;
       renderConfig();
-      const btn = document.getElementById("btn-import-config");
-      const orig = btn.textContent;
-      btn.textContent = "インポートしました";
-      setTimeout(() => { btn.textContent = orig; }, 1500);
+      alert("設定ファイルをインポートしました。");
     }
   } catch (e) {
     alert("インポートに失敗しました:\n" + e);

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -487,6 +487,38 @@ listen("kanata-status-changed", (event) => {
   updateKanataUI(event.payload);
 });
 
+// ── Config export / import ──
+document.getElementById("btn-export-config").addEventListener("click", async () => {
+  try {
+    const exported = await invoke("export_config");
+    if (exported) {
+      const btn = document.getElementById("btn-export-config");
+      const orig = btn.textContent;
+      btn.textContent = "エクスポートしました";
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    }
+  } catch (e) {
+    alert("エクスポートに失敗しました:\n" + e);
+  }
+});
+
+document.getElementById("btn-import-config").addEventListener("click", async () => {
+  if (!confirm("現在の設定を上書きします。よろしいですか？")) return;
+  try {
+    const newConfig = await invoke("import_config");
+    if (newConfig) {
+      config = newConfig;
+      renderConfig();
+      const btn = document.getElementById("btn-import-config");
+      const orig = btn.textContent;
+      btn.textContent = "インポートしました";
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    }
+  } catch (e) {
+    alert("インポートに失敗しました:\n" + e);
+  }
+});
+
 // ── General tab: help / install dir / quit ──
 document.getElementById("btn-help").addEventListener("click", async () => {
   try {

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -1,5 +1,6 @@
 const { invoke } = window.__TAURI__.core;
 const { listen } = window.__TAURI__.event;
+const { message, ask } = window.__TAURI__.dialog;
 
 // ── State ──
 let config = null;       // Current config from backend
@@ -427,7 +428,7 @@ document.getElementById("btn-apply").addEventListener("click", async () => {
     // Client-side dispatch key validation
     const dupError = validateDispatchKeys();
     if (dupError) {
-      alert(dupError);
+      await message(dupError, { title: "エラー", kind: "error" });
       return;
     }
 
@@ -443,7 +444,7 @@ document.getElementById("btn-apply").addEventListener("click", async () => {
     setTimeout(() => { btn.textContent = orig; }, 1500);
   } catch (e) {
     console.error("[apply] error:", e);
-    alert("保存に失敗しました:\n" + e);
+    await message("保存に失敗しました:\n" + e, { title: "エラー", kind: "error" });
   }
 });
 
@@ -492,24 +493,25 @@ document.getElementById("btn-export-config").addEventListener("click", async () 
   try {
     const exported = await invoke("export_config");
     if (exported) {
-      alert("設定ファイルをエクスポートしました。");
+      await message("設定ファイルをエクスポートしました。", { title: "エクスポート" });
     }
   } catch (e) {
-    alert("エクスポートに失敗しました:\n" + e);
+    await message("エクスポートに失敗しました:\n" + e, { title: "エラー", kind: "error" });
   }
 });
 
 document.getElementById("btn-import-config").addEventListener("click", async () => {
-  if (!confirm("現在の設定を上書きします。よろしいですか？")) return;
+  const ok = await ask("現在の設定を上書きします。よろしいですか？", { title: "インポート", kind: "warning" });
+  if (!ok) return;
   try {
     const newConfig = await invoke("import_config");
     if (newConfig) {
       config = newConfig;
       renderConfig();
-      alert("設定ファイルをインポートしました。");
+      await message("設定ファイルをインポートしました。", { title: "インポート" });
     }
   } catch (e) {
-    alert("インポートに失敗しました:\n" + e);
+    await message("インポートに失敗しました:\n" + e, { title: "エラー", kind: "error" });
   }
 });
 
@@ -531,7 +533,7 @@ document.getElementById("btn-open-dir").addEventListener("click", async () => {
   try {
     await invoke("open_install_dir");
   } catch (e) {
-    alert("インストール先を開けませんでした:\n" + e);
+    await message("インストール先を開けませんでした:\n" + e, { title: "エラー", kind: "error" });
   }
 });
 
@@ -568,16 +570,16 @@ async function checkForUpdate(silent = true) {
   try {
     const update = await invoke("check_update");
     if (update) {
-      if (confirm(`新しいバージョン ${update.version} が利用可能です。\nアップデートしますか？`)) {
+      if (await ask(`新しいバージョン ${update.version} が利用可能です。\nアップデートしますか？`, { title: "アップデート" })) {
         await invoke("stop_kanata");
         await invoke("install_update");
       }
     } else if (!silent) {
-      alert("現在のバージョンは最新です。");
+      await message("現在のバージョンは最新です。", { title: "アップデート" });
     }
   } catch (e) {
     console.error("[updater]", e);
-    if (!silent) alert("アップデート確認に失敗しました:\n" + e);
+    if (!silent) await message("アップデート確認に失敗しました:\n" + e, { title: "エラー", kind: "error" });
   }
 }
 

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -47,11 +47,14 @@ pub async fn export_config(app: tauri::AppHandle) -> Result<bool, String> {
     use tauri_plugin_dialog::DialogExt;
     let src = resolve_config_path();
     let (tx, rx) = std::sync::mpsc::channel();
-    app.dialog()
-        .file()
-        .add_filter("TOML", &["toml"])
-        .set_file_name("config.toml")
-        .save_file(move |path| {
+    let default_dir = dirs::desktop_dir()
+        .or_else(dirs::download_dir)
+        .or_else(dirs::home_dir);
+    let mut builder = app.dialog().file().add_filter("TOML", &["toml"]).set_file_name("muhenkan-switch-config.toml");
+    if let Some(dir) = default_dir {
+        builder = builder.set_directory(dir);
+    }
+    builder.save_file(move |path| {
             let _ = tx.send(path.map(|p| p.as_path().unwrap().to_path_buf()));
         });
     let dest = rx.recv().map_err(|e| e.to_string())?;

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -42,6 +42,54 @@ pub fn default_config() -> Config {
     config::default_config()
 }
 
+#[tauri::command]
+pub async fn export_config(app: tauri::AppHandle) -> Result<bool, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let src = resolve_config_path();
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.dialog()
+        .file()
+        .add_filter("TOML", &["toml"])
+        .set_file_name("config.toml")
+        .save_file(move |path| {
+            let _ = tx.send(path.map(|p| p.as_path().unwrap().to_path_buf()));
+        });
+    let dest = rx.recv().map_err(|e| e.to_string())?;
+    match dest {
+        Some(dest) => {
+            std::fs::copy(&src, &dest).map_err(|e| e.to_string())?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+#[tauri::command]
+pub async fn import_config(app: tauri::AppHandle) -> Result<Option<Config>, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.dialog()
+        .file()
+        .add_filter("TOML", &["toml"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.as_path().unwrap().to_path_buf()));
+        });
+    let selected = rx.recv().map_err(|e| e.to_string())?;
+    match selected {
+        Some(src) => {
+            let imported = config::load_from(&src).map_err(|e| e.to_string())?;
+            let errors = config::validate(&imported);
+            if !errors.is_empty() {
+                return Err(errors.join("\n"));
+            }
+            let dest = resolve_config_path();
+            config::save(&dest, &imported).map_err(|e| e.to_string())?;
+            Ok(Some(imported))
+        }
+        None => Ok(None),
+    }
+}
+
 // ── Kanata commands ──
 
 #[derive(Serialize, Clone)]

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -40,6 +40,8 @@ fn main() {
             commands::save_config,
             commands::reset_config,
             commands::default_config,
+            commands::export_config,
+            commands::import_config,
             commands::get_kanata_status,
             commands::start_kanata,
             commands::stop_kanata,


### PR DESCRIPTION
## Summary
- 全般タブに「設定管理」fieldset を追加し、エクスポート/インポートボタンを配置
- エクスポート: `std::fs::copy` で config.toml をファイル保存ダイアログで任意の場所にコピー（コメント保持）
- インポート: ファイル選択 → `load_from` でパース → `validate` でバリデーション → `save` で上書き → UI 再描画
- `dialog:allow-save` 権限を追加

## Test plan
- [x] エクスポートボタンを押してファイル保存ダイアログが表示されることを確認
- [x] 任意の場所に config.toml がコピーされることを確認
- [x] インポートボタンを押して確認ダイアログ → ファイル選択ダイアログが表示されることを確認
- [ ] 有効な config.toml をインポートして UI が再描画されることを確認
- [ ] 不正な TOML ファイルをインポートしてエラーが表示されることを確認
- [x] ダイアログをキャンセルした場合に何も起きないことを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)