### PR TITLE
fix: dev タスク起動前に残存プロセスを kill して Permission denied を防止

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -255,6 +255,12 @@ depends = ["build", "fetch-kanata"]
 shell = "bash -c"
 run = """
 EXT=""; [ "$OS" = "Windows_NT" ] && EXT=".exe"
+
+# 前回のプロセスが残っていれば終了させる
+if [ "$OS" = "Windows_NT" ]; then
+  taskkill //F //IM muhenkan-switch.exe 2>/dev/null || true
+fi
+
 echo "[dev] Starting GUI from ./bin/ ..."
 ./bin/muhenkan-switch${EXT}
 """


### PR DESCRIPTION
## Summary
- `mise run dev` の起動前に `taskkill //F //IM muhenkan-switch.exe` で前回の残存プロセスを終了させる
- Ctrl+C で終了できなかった場合にプロセスが残り、次回起動時に Permission denied が発生する問題を解消

Closes #64

## Test plan
- [x] `mise run dev` で GUI 起動後、タスクマネージャーで強制終了
- [x] 直後に `mise run dev` → Permission denied なく起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)