### PR TITLE
refactor: タイムスタンプ貼り付けをクリップボード経由から直接入力に変更

### DIFF
--- a/muhenkan-switch-core/src/commands/keys.rs
+++ b/muhenkan-switch-core/src/commands/keys.rs
@@ -4,8 +4,8 @@ pub fn simulate_copy() -> Result<()> {
     imp::simulate_copy()
 }
 
-pub fn simulate_paste() -> Result<()> {
-    imp::simulate_paste()
+pub fn simulate_type(text: &str) -> Result<()> {
+    imp::simulate_type(text)
 }
 
 // ── Platform: Windows ──
@@ -15,16 +15,45 @@ mod imp {
     use super::*;
     use std::mem;
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VIRTUAL_KEY, VK_C,
-        VK_CONTROL, VK_V,
+        SendInput, INPUT, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE,
+        VIRTUAL_KEY, VK_C, VK_CONTROL,
     };
 
     pub(super) fn simulate_copy() -> Result<()> {
         send_ctrl_key(VK_C)
     }
 
-    pub(super) fn simulate_paste() -> Result<()> {
-        send_ctrl_key(VK_V)
+    pub(super) fn simulate_type(text: &str) -> Result<()> {
+        let mut inputs: Vec<INPUT> = Vec::new();
+        for c in text.encode_utf16() {
+            let mut down = INPUT::default();
+            down.r#type = INPUT_KEYBOARD;
+            down.Anonymous.ki = KEYBDINPUT {
+                wScan: c,
+                dwFlags: KEYEVENTF_UNICODE,
+                ..Default::default()
+            };
+            let mut up = INPUT::default();
+            up.r#type = INPUT_KEYBOARD;
+            up.Anonymous.ki = KEYBDINPUT {
+                wScan: c,
+                dwFlags: KEYEVENTF_UNICODE | KEYEVENTF_KEYUP,
+                ..Default::default()
+            };
+            inputs.push(down);
+            inputs.push(up);
+        }
+        unsafe {
+            let sent = SendInput(&inputs, mem::size_of::<INPUT>() as i32);
+            if sent != inputs.len() as u32 {
+                anyhow::bail!(
+                    "SendInput failed: only {} of {} inputs sent",
+                    sent,
+                    inputs.len()
+                );
+            }
+        }
+        Ok(())
     }
 
     /// Send Ctrl+<key> via Win32 SendInput.
@@ -85,9 +114,9 @@ mod imp {
         Ok(())
     }
 
-    pub(super) fn simulate_paste() -> Result<()> {
+    pub(super) fn simulate_type(text: &str) -> Result<()> {
         Command::new("xdotool")
-            .args(["key", "ctrl+v"])
+            .args(["type", "--clearmodifiers", text])
             .output()?;
         Ok(())
     }
@@ -110,11 +139,14 @@ mod imp {
         Ok(())
     }
 
-    pub(super) fn simulate_paste() -> Result<()> {
+    pub(super) fn simulate_type(text: &str) -> Result<()> {
         Command::new("osascript")
             .args([
                 "-e",
-                r#"tell application "System Events" to keystroke "v" using command down"#,
+                &format!(
+                    r#"tell application "System Events" to keystroke "{}""#,
+                    text
+                ),
             ])
             .output()?;
         Ok(())

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use arboard::Clipboard;
 use chrono::Local;
 use std::path::{Path, PathBuf};
 
@@ -81,18 +80,9 @@ fn format_toast_result(result: &Result<Vec<PathBuf>>) -> String {
 
 // ── テキスト入力コンテキスト ──
 
-/// V: タイムスタンプをカーソル位置に貼り付け（クリップボード復元付き）
+/// V: タイムスタンプをカーソル位置に直接入力
 fn text_paste(timestamp: &str) -> Result<()> {
-    let mut clipboard = Clipboard::new()?;
-    let saved = clipboard.get_text().ok();
-    clipboard.set_text(timestamp)?;
-    super::keys::simulate_paste()?;
-    // ペースト完了を待ってからクリップボードを復元
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    if let Some(text) = saved {
-        let _ = clipboard.set_text(text);
-    }
-    Ok(())
+    super::keys::simulate_type(timestamp)
 }
 
 // ── Explorer コンテキスト ──


### PR DESCRIPTION
## Summary
- テキストコンテキストでのタイムスタンプ貼り付け（無変換+V）を、クリップボード経由の Ctrl+V シミュレートから `SendInput` + `KEYEVENTF_UNICODE` による直接入力に変更
- クリップボード内容の一時破壊と 100ms 待機を排除
- 不要になった `simulate_paste` を全プラットフォームから削除

Closes #68

## Test plan
- [ ] テキストエディタで無変換+V → タイムスタンプが入力されること
- [ ] 入力前後でクリップボードの内容が変わらないこと
- [ ] エクスプローラーでの V/C/X 操作は従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)