### PR TITLE
feat: キーボード配列図 SVG の自動生成とヘルプ画面表示

### DIFF
--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -3,6 +3,8 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub mod svg;
+
 // ── Dispatch keys ──
 
 /// kbd ファイルでディスパッチに割り当てられている物理キーの一覧。

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -1,0 +1,326 @@
+use crate::Config;
+
+/// キーの物理配置を定義する構造体。
+struct KeyDef {
+    /// 物理キー名（大文字表示用）
+    label: &'static str,
+    /// config 検索用（小文字）
+    dispatch_key: Option<&'static str>,
+    /// SVG 上の x 座標
+    x: f64,
+    /// SVG 上の y 座標
+    y: f64,
+    /// キーのカテゴリ
+    category: KeyCategory,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum KeyCategory {
+    /// 左手ディスパッチキー（config で色が決まる）
+    Dispatch,
+    /// タイムスタンプキー（V, C, X）
+    Timestamp,
+    /// 右手テキスト編集キー（固定）
+    TextEdit,
+    /// 無変換レイヤーで未使用のキー
+    Unused,
+}
+
+/// 右手キーの固定機能名。
+/// 右手キーの固定機能名（kanata/muhenkan.kbd の mh-layer 定義に準拠）。
+fn text_edit_label(key: &str) -> &'static str {
+    match key {
+        // hjkl: Vim 風カーソル移動
+        "H" => "←",
+        "J" => "↓",
+        "K" => "↑",
+        "L" => "→",
+        // uiyo: 単語移動 / 行頭行末
+        "U" => "単語←",
+        "I" => "単語→",
+        "Y" => "Home",
+        "O" => "End",
+        // nm;: 削除
+        "N" => "BS",
+        "M" => "Del",
+        ";" => "Esc",
+        // ,.: インデント操作
+        "," => "逆字下",
+        "." => "字下げ",
+        _ => "",
+    }
+}
+
+/// タイムスタンプキーの固定機能名。
+fn timestamp_label(key: &str) -> &'static str {
+    match key {
+        "V" => "付与",
+        "C" => "複製",
+        "X" => "除去",
+        _ => "",
+    }
+}
+
+const KEY_W: f64 = 52.0;
+const KEY_H: f64 = 52.0;
+const KEY_GAP: f64 = 4.0;
+const KEY_PITCH: f64 = KEY_W + KEY_GAP; // 56.0
+const CORNER_R: f64 = 6.0;
+const FONT_SIZE_TOP: f64 = 13.0;
+const FONT_SIZE_BOTTOM: f64 = 11.0;
+
+/// QWERTY 物理配列の (row, col) から SVG 座標を計算するヘルパー。
+/// row: 0=数字行, 1=Q行, 2=A行(ホーム), 3=Z行
+/// col: QWERTY 列番号 (1→0, Q→0, A→0, Z→0)
+/// hand_gap: 左右の手の間に挿入する追加幅
+fn qwerty_pos(row: usize, col: usize, hand_gap: f64) -> (f64, f64) {
+    let pad = 20.0;
+    // QWERTY 行スタガー（左端キーからの X オフセット）
+    let row_offset = match row {
+        0 => 0.0,                // 数字行
+        1 => KEY_PITCH * 0.5,   // Q行（Tab 幅分）
+        2 => KEY_PITCH * 0.75,  // A行（CapsLock 幅分）
+        _ => KEY_PITCH * 1.25,  // Z行（Shift 幅分）
+    };
+    let x = pad + row_offset + col as f64 * KEY_PITCH + hand_gap;
+    let y = pad + row as f64 * KEY_PITCH;
+    (x, y)
+}
+
+/// JIS キーボードの QWERTY 物理配列に基づくキー定義を生成する。
+fn key_definitions() -> Vec<KeyDef> {
+    // 左右の手の間（col 4→5 の間）に挿入するギャップ
+    let gap = KEY_PITCH * 1.5;
+
+    // ヘルパー: 左手キー (gap なし)
+    let l = |row, col| -> (f64, f64) { qwerty_pos(row, col, 0.0) };
+    // ヘルパー: 右手キー (gap あり)
+    let r = |row, col| -> (f64, f64) { qwerty_pos(row, col, gap) };
+
+    vec![
+        // ── 数字行 (row 0) ──
+        //   1(c0) 2(c1) 3(c2) 4(c3) 5(c4)  6(c5) 7(c6) 8(c7) 9(c8) 0(c9)
+        KeyDef { label: "1", dispatch_key: Some("1"), x: l(0,0).0, y: l(0,0).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "2", dispatch_key: Some("2"), x: l(0,1).0, y: l(0,1).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "3", dispatch_key: Some("3"), x: l(0,2).0, y: l(0,2).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "4", dispatch_key: Some("4"), x: l(0,3).0, y: l(0,3).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "5", dispatch_key: Some("5"), x: l(0,4).0, y: l(0,4).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "6", dispatch_key: None, x: r(0,5).0, y: r(0,5).1, category: KeyCategory::Unused },
+        KeyDef { label: "7", dispatch_key: None, x: r(0,6).0, y: r(0,6).1, category: KeyCategory::Unused },
+        KeyDef { label: "8", dispatch_key: None, x: r(0,7).0, y: r(0,7).1, category: KeyCategory::Unused },
+        KeyDef { label: "9", dispatch_key: None, x: r(0,8).0, y: r(0,8).1, category: KeyCategory::Unused },
+        KeyDef { label: "0", dispatch_key: None, x: r(0,9).0, y: r(0,9).1, category: KeyCategory::Unused },
+        // ── Q行 (row 1) ──
+        //   Q(c0) W(c1) E(c2) R(c3) T(c4)  |  Y(c5) U(c6) I(c7) O(c8) P(c9)
+        KeyDef { label: "Q", dispatch_key: Some("q"), x: l(1,0).0, y: l(1,0).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "W", dispatch_key: Some("w"), x: l(1,1).0, y: l(1,1).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "E", dispatch_key: Some("e"), x: l(1,2).0, y: l(1,2).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "R", dispatch_key: Some("r"), x: l(1,3).0, y: l(1,3).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "T", dispatch_key: Some("t"), x: l(1,4).0, y: l(1,4).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "Y", dispatch_key: None, x: r(1,5).0, y: r(1,5).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "U", dispatch_key: None, x: r(1,6).0, y: r(1,6).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "I", dispatch_key: None, x: r(1,7).0, y: r(1,7).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "O", dispatch_key: None, x: r(1,8).0, y: r(1,8).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "P", dispatch_key: None, x: r(1,9).0, y: r(1,9).1, category: KeyCategory::Unused },
+        // ── A行 / ホーム行 (row 2) ──
+        //   A(c0) S(c1) D(c2) F(c3) G(c4)  |  H(c5) J(c6) K(c7) L(c8) ;(c9)
+        KeyDef { label: "A", dispatch_key: Some("a"), x: l(2,0).0, y: l(2,0).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "S", dispatch_key: Some("s"), x: l(2,1).0, y: l(2,1).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "D", dispatch_key: Some("d"), x: l(2,2).0, y: l(2,2).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "F", dispatch_key: Some("f"), x: l(2,3).0, y: l(2,3).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "G", dispatch_key: Some("g"), x: l(2,4).0, y: l(2,4).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "H", dispatch_key: None, x: r(2,5).0, y: r(2,5).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "J", dispatch_key: None, x: r(2,6).0, y: r(2,6).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "K", dispatch_key: None, x: r(2,7).0, y: r(2,7).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "L", dispatch_key: None, x: r(2,8).0, y: r(2,8).1, category: KeyCategory::TextEdit },
+        KeyDef { label: ";", dispatch_key: None, x: r(2,9).0, y: r(2,9).1, category: KeyCategory::TextEdit },
+        // ── Z行 / 下行 (row 3) ──
+        //   Z(c0) X(c1) C(c2) V(c3) B(c4)  |  N(c5) M(c6) ,(c7) .(c8) /(c9)
+        KeyDef { label: "Z", dispatch_key: None, x: l(3,0).0, y: l(3,0).1, category: KeyCategory::Unused },
+        KeyDef { label: "X", dispatch_key: None, x: l(3,1).0, y: l(3,1).1, category: KeyCategory::Timestamp },
+        KeyDef { label: "C", dispatch_key: None, x: l(3,2).0, y: l(3,2).1, category: KeyCategory::Timestamp },
+        KeyDef { label: "V", dispatch_key: None, x: l(3,3).0, y: l(3,3).1, category: KeyCategory::Timestamp },
+        KeyDef { label: "B", dispatch_key: Some("b"), x: l(3,4).0, y: l(3,4).1, category: KeyCategory::Dispatch },
+        KeyDef { label: "N", dispatch_key: None, x: r(3,5).0, y: r(3,5).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "M", dispatch_key: None, x: r(3,6).0, y: r(3,6).1, category: KeyCategory::TextEdit },
+        KeyDef { label: ",", dispatch_key: None, x: r(3,7).0, y: r(3,7).1, category: KeyCategory::TextEdit },
+        KeyDef { label: ".", dispatch_key: None, x: r(3,8).0, y: r(3,8).1, category: KeyCategory::TextEdit },
+        KeyDef { label: "/", dispatch_key: None, x: r(3,9).0, y: r(3,9).1, category: KeyCategory::Unused },
+    ]
+}
+
+/// config のディスパッチキーに対する割当カテゴリとエントリ名を返す。
+fn lookup_dispatch<'a>(config: &'a Config, key: &str) -> Option<(&'static str, &'a str)> {
+    for (name, entry) in &config.folders {
+        if entry.dispatch_key() == Some(key) {
+            return Some(("folder", name.as_str()));
+        }
+    }
+    for (name, entry) in &config.search {
+        if entry.dispatch_key() == Some(key) {
+            return Some(("search", name.as_str()));
+        }
+    }
+    for (name, entry) in &config.apps {
+        if entry.dispatch_key() == Some(key) {
+            return Some(("app", name.as_str()));
+        }
+    }
+    None
+}
+
+/// カテゴリに応じた塗り色を返す。
+fn fill_color(category: &str) -> &'static str {
+    match category {
+        "folder" => "#fff2cc",
+        "search" => "#ffe6cc",
+        "app" => "#f8cecc",
+        "timestamp" => "#e1d5e7",
+        "textedit" => "#dae8fc",
+        "unused" => "#d9d9d9",
+        _ => "#f5f5f5", // 未割当（ディスパッチ可能だが config 未設定）
+    }
+}
+
+/// XML 特殊文字をエスケープする。
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// config.toml の内容からキーボードレイアウト SVG を生成する。
+pub fn generate(config: &Config) -> String {
+    let keys = key_definitions();
+
+    // SVG サイズを計算
+    let max_x = keys.iter().map(|k| k.x + KEY_W).fold(0.0f64, f64::max);
+    let max_y = keys.iter().map(|k| k.y + KEY_H).fold(0.0f64, f64::max);
+    let svg_w = max_x + 20.0;
+    let svg_h = max_y + 20.0;
+
+    let mut svg = format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}" width="{svg_w}" height="{svg_h}" font-family="sans-serif">"#,
+    );
+
+    // 背景
+    svg.push_str(&format!(
+        r##"<rect width="{svg_w}" height="{svg_h}" fill="#ffffff" rx="8"/>"##,
+    ));
+
+    for key in &keys {
+        let (fill, bottom_label) = match key.category {
+            KeyCategory::TextEdit => {
+                (fill_color("textedit"), text_edit_label(key.label).to_string())
+            }
+            KeyCategory::Timestamp => {
+                (fill_color("timestamp"), timestamp_label(key.label).to_string())
+            }
+            KeyCategory::Unused => {
+                (fill_color("unused"), String::new())
+            }
+            KeyCategory::Dispatch => {
+                if let Some(dk) = key.dispatch_key {
+                    if let Some((cat, name)) = lookup_dispatch(config, dk) {
+                        (fill_color(cat), name.to_string())
+                    } else {
+                        (fill_color("unassigned"), String::new())
+                    }
+                } else {
+                    (fill_color("unassigned"), String::new())
+                }
+            }
+        };
+
+        // キー矩形
+        svg.push_str(&format!(
+            r##"<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{r}" fill="{fill}" stroke="#999" stroke-width="1"/>"##,
+            x = key.x,
+            y = key.y,
+            w = KEY_W,
+            h = KEY_H,
+            r = CORNER_R,
+        ));
+
+        // 上段ラベル（物理キー名）
+        let top_y = key.y + 18.0;
+        let cx = key.x + KEY_W / 2.0;
+        svg.push_str(&format!(
+            r##"<text x="{cx}" y="{top_y}" text-anchor="middle" font-size="{fs}" font-weight="bold" fill="#333">{label}</text>"##,
+            fs = FONT_SIZE_TOP,
+            label = xml_escape(key.label),
+        ));
+
+        // 下段ラベル（機能名/エントリ名）
+        if !bottom_label.is_empty() {
+            let bot_y = key.y + 38.0;
+            let escaped = xml_escape(&bottom_label);
+            // 長いラベルはフォントサイズを縮小
+            let fs = if bottom_label.len() > 6 {
+                FONT_SIZE_BOTTOM - 2.0
+            } else {
+                FONT_SIZE_BOTTOM
+            };
+            svg.push_str(&format!(
+                r##"<text x="{cx}" y="{bot_y}" text-anchor="middle" font-size="{fs}" fill="#666">{escaped}</text>"##,
+            ));
+        }
+    }
+
+    svg.push_str("</svg>");
+    svg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::default_config;
+
+    #[test]
+    fn test_generate_default_config() {
+        let config = default_config();
+        let svg = generate(&config);
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.ends_with("</svg>"));
+    }
+
+    #[test]
+    fn test_svg_contains_entry_names() {
+        let config = default_config();
+        let svg = generate(&config);
+        assert!(svg.contains("google"), "SVG should contain 'google'");
+        assert!(svg.contains("ejje"), "SVG should contain 'ejje'");
+    }
+
+    #[test]
+    fn test_svg_contains_text_edit_labels() {
+        let config = default_config();
+        let svg = generate(&config);
+        assert!(svg.contains("←"), "SVG should contain arrow label");
+        assert!(svg.contains("Home"), "SVG should contain 'Home'");
+    }
+
+    #[test]
+    fn test_empty_config_no_error() {
+        let config: Config = toml::from_str("[search]\n[folders]\n[apps]\n").unwrap();
+        let svg = generate(&config);
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.ends_with("</svg>"));
+    }
+
+    #[test]
+    fn test_svg_valid_xml_structure() {
+        let config = default_config();
+        let svg = generate(&config);
+        let rect_count = svg.matches("<rect ").count();
+        let expected_keys = key_definitions().len();
+        assert_eq!(
+            rect_count,
+            expected_keys + 1,
+            "Expected {} rects (1 bg + {} keys)",
+            expected_keys + 1,
+            expected_keys
+        );
+    }
+}

--- a/muhenkan-switch-core/src/main.rs
+++ b/muhenkan-switch-core/src/main.rs
@@ -48,6 +48,15 @@ enum Commands {
     },
     /// GUI 設定ウィンドウを前面に出す（未起動なら起動する）
     OpenGui,
+    /// キーボードレイアウト図を SVG で生成
+    GenerateSvg {
+        /// 出力ファイルパス（省略時は stdout）
+        #[arg(short, long)]
+        output: Option<String>,
+        /// config.toml パス（省略時は自動検出）
+        #[arg(short, long)]
+        config: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -58,6 +67,24 @@ fn main() -> Result<()> {
         return commands::open_gui::run();
     }
 
+    // GenerateSvg は独自の config 読み込みを行う
+    if let Commands::GenerateSvg {
+        ref output,
+        ref config,
+    } = cli.command
+    {
+        let cfg = match config {
+            Some(path) => muhenkan_switch_config::load_from(std::path::Path::new(path))?,
+            None => muhenkan_switch_config::load()?,
+        };
+        let svg = muhenkan_switch_config::svg::generate(&cfg);
+        match output {
+            Some(path) => std::fs::write(path, &svg)?,
+            None => print!("{}", svg),
+        }
+        return Ok(());
+    }
+
     let config = config::load()?;
 
     match cli.command {
@@ -66,6 +93,6 @@ fn main() -> Result<()> {
         Commands::OpenFolder { target } => commands::open_folder::run(&target, &config),
         Commands::Timestamp { action } => commands::timestamp::run(&action, &config),
         Commands::Dispatch { key } => commands::dispatch::run(&key, &config),
-        Commands::OpenGui => unreachable!(),
+        Commands::OpenGui | Commands::GenerateSvg { .. } => unreachable!(),
     }
 }

--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -13,7 +13,7 @@
       background: #1e1e2e;
       line-height: 1.6;
     }
-    .help { max-width: 640px; margin: 0 auto; padding: 20px 24px; }
+    .help { max-width: 800px; margin: 0 auto; padding: 20px 24px; }
     h1 { font-size: 18px; font-weight: 700; margin-bottom: 16px; color: #89b4fa; }
     h2 { font-size: 14px; font-weight: 600; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
     section { margin-bottom: 20px; }
@@ -31,7 +31,10 @@
     ol { padding-left: 20px; }
     ol li { margin-bottom: 4px; }
     code { font-family: "Cascadia Code", "Consolas", monospace; font-size: 12px; color: #8888aa; }
-    #keyboard-svg svg { width: 100%; height: auto; }
+    #keyboard-svg { overflow: hidden; cursor: grab; border-radius: 6px; }
+    #keyboard-svg.dragging { cursor: grabbing; }
+    #keyboard-svg svg { display: block; transform-origin: 0 0; }
+    #keyboard-svg-hint { font-size: 11px; color: #8888aa; margin-top: 4px; }
     .legend { display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 12px; }
     .legend-item { display: flex; align-items: center; gap: 4px; }
     .legend-color { display: inline-block; width: 14px; height: 14px; min-width: 14px; min-height: 14px; border: 1px solid #45475a; border-radius: 2px; flex-shrink: 0; overflow: hidden; font-size: 0; }
@@ -51,7 +54,8 @@
     <section>
       <h2>キーボード配列</h2>
       <p>無変換キーを押しながら使うキーの一覧です。色はカテゴリを表します。</p>
-      <div id="keyboard-svg" style="margin: 12px 0; overflow-x: auto;"></div>
+      <div id="keyboard-svg" style="margin: 12px 0;"></div>
+      <p id="keyboard-svg-hint">ホイールで拡大縮小 / ドラッグで移動 / ダブルクリックでリセット</p>
       <div class="legend">
         <span class="legend-item"><span class="legend-color lc-folder">&nbsp;</span>フォルダ</span>
         <span class="legend-item"><span class="legend-color lc-search">&nbsp;</span>検索</span>
@@ -128,7 +132,47 @@
     // キーボード配列 SVG を Tauri 経由で取得して埋め込む
     if (window.__TAURI__) {
       window.__TAURI__.core.invoke("generate_keyboard_svg").then(svg => {
-        document.getElementById("keyboard-svg").innerHTML = svg;
+        const container = document.getElementById("keyboard-svg");
+        container.innerHTML = svg;
+        const svgEl = container.querySelector("svg");
+        if (!svgEl) return;
+
+        let scale = 1, tx = 0, ty = 0;
+        function apply() {
+          svgEl.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+        }
+        // ホイールでズーム（コンテナ上のみ）
+        container.addEventListener("wheel", e => {
+          e.preventDefault();
+          const rect = container.getBoundingClientRect();
+          const mx = e.clientX - rect.left;
+          const my = e.clientY - rect.top;
+          const old = scale;
+          scale = Math.min(5, Math.max(0.5, scale * (e.deltaY < 0 ? 1.12 : 0.88)));
+          const r = scale / old;
+          tx = mx - r * (mx - tx);
+          ty = my - r * (my - ty);
+          apply();
+        }, { passive: false });
+        // ドラッグで移動
+        let dragging = false, sx = 0, sy = 0;
+        container.addEventListener("mousedown", e => {
+          if (e.button === 0) {
+            dragging = true; sx = e.clientX - tx; sy = e.clientY - ty;
+            container.classList.add("dragging");
+            e.preventDefault();
+          }
+        });
+        document.addEventListener("mousemove", e => {
+          if (dragging) { tx = e.clientX - sx; ty = e.clientY - sy; apply(); }
+        });
+        document.addEventListener("mouseup", () => {
+          dragging = false; container.classList.remove("dragging");
+        });
+        // ダブルクリックでリセット
+        container.addEventListener("dblclick", () => {
+          scale = 1; tx = 0; ty = 0; apply();
+        });
       }).catch(err => {
         document.getElementById("keyboard-svg").textContent = "キーボード図の読み込みに失敗しました: " + err;
       });

--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -131,51 +131,61 @@
     }
     // キーボード配列 SVG を Tauri 経由で取得して埋め込む
     if (window.__TAURI__) {
-      window.__TAURI__.core.invoke("generate_keyboard_svg").then(svg => {
-        const container = document.getElementById("keyboard-svg");
-        container.innerHTML = svg;
-        const svgEl = container.querySelector("svg");
-        if (!svgEl) return;
+      const container = document.getElementById("keyboard-svg");
+      let scale = 1, tx = 0, ty = 0, dragging = false, sx = 0, sy = 0;
 
-        let scale = 1, tx = 0, ty = 0;
-        function apply() {
-          svgEl.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
-        }
-        // ホイールでズーム（コンテナ上のみ）
-        container.addEventListener("wheel", e => {
+      function loadSvg() {
+        window.__TAURI__.core.invoke("generate_keyboard_svg").then(svg => {
+          container.innerHTML = svg;
+          scale = 1; tx = 0; ty = 0;
+          const svgEl = container.querySelector("svg");
+          if (svgEl) svgEl.style.transform = "";
+        }).catch(err => {
+          container.textContent = "キーボード図の読み込みに失敗しました: " + err;
+        });
+      }
+
+      function applySvgTransform() {
+        const svgEl = container.querySelector("svg");
+        if (svgEl) svgEl.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+      }
+
+      // ホイールでズーム（コンテナ上のみ）
+      container.addEventListener("wheel", e => {
+        e.preventDefault();
+        const rect = container.getBoundingClientRect();
+        const mx = e.clientX - rect.left;
+        const my = e.clientY - rect.top;
+        const old = scale;
+        scale = Math.min(5, Math.max(0.5, scale * (e.deltaY < 0 ? 1.12 : 0.88)));
+        const r = scale / old;
+        tx = mx - r * (mx - tx);
+        ty = my - r * (my - ty);
+        applySvgTransform();
+      }, { passive: false });
+      // ドラッグで移動
+      container.addEventListener("mousedown", e => {
+        if (e.button === 0) {
+          dragging = true; sx = e.clientX - tx; sy = e.clientY - ty;
+          container.classList.add("dragging");
           e.preventDefault();
-          const rect = container.getBoundingClientRect();
-          const mx = e.clientX - rect.left;
-          const my = e.clientY - rect.top;
-          const old = scale;
-          scale = Math.min(5, Math.max(0.5, scale * (e.deltaY < 0 ? 1.12 : 0.88)));
-          const r = scale / old;
-          tx = mx - r * (mx - tx);
-          ty = my - r * (my - ty);
-          apply();
-        }, { passive: false });
-        // ドラッグで移動
-        let dragging = false, sx = 0, sy = 0;
-        container.addEventListener("mousedown", e => {
-          if (e.button === 0) {
-            dragging = true; sx = e.clientX - tx; sy = e.clientY - ty;
-            container.classList.add("dragging");
-            e.preventDefault();
-          }
-        });
-        document.addEventListener("mousemove", e => {
-          if (dragging) { tx = e.clientX - sx; ty = e.clientY - sy; apply(); }
-        });
-        document.addEventListener("mouseup", () => {
-          dragging = false; container.classList.remove("dragging");
-        });
-        // ダブルクリックでリセット
-        container.addEventListener("dblclick", () => {
-          scale = 1; tx = 0; ty = 0; apply();
-        });
-      }).catch(err => {
-        document.getElementById("keyboard-svg").textContent = "キーボード図の読み込みに失敗しました: " + err;
+        }
       });
+      document.addEventListener("mousemove", e => {
+        if (dragging) { tx = e.clientX - sx; ty = e.clientY - sy; applySvgTransform(); }
+      });
+      document.addEventListener("mouseup", () => {
+        dragging = false; container.classList.remove("dragging");
+      });
+      // ダブルクリックでリセット
+      container.addEventListener("dblclick", () => {
+        scale = 1; tx = 0; ty = 0; applySvgTransform();
+      });
+
+      // 初回読み込み
+      loadSvg();
+      // 設定保存時に自動更新
+      window.__TAURI__.event.listen("config-saved", () => { loadSvg(); });
     }
   </script>
 </body>

--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -31,11 +31,37 @@
     ol { padding-left: 20px; }
     ol li { margin-bottom: 4px; }
     code { font-family: "Cascadia Code", "Consolas", monospace; font-size: 12px; color: #8888aa; }
+    #keyboard-svg svg { width: 100%; height: auto; }
+    .legend { display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 12px; }
+    .legend-item { display: flex; align-items: center; gap: 4px; }
+    .legend-color { display: inline-block; width: 14px; height: 14px; min-width: 14px; min-height: 14px; border: 1px solid #45475a; border-radius: 2px; flex-shrink: 0; overflow: hidden; font-size: 0; }
+    .lc-folder   { background-color: #fff2cc !important; }
+    .lc-search   { background-color: #ffe6cc !important; }
+    .lc-app      { background-color: #f8cecc !important; }
+    .lc-ts       { background-color: #e1d5e7 !important; }
+    .lc-edit     { background-color: #dae8fc !important; }
+    .lc-unset    { background-color: #f5f5f5 !important; }
+    .lc-unused   { background-color: #d9d9d9 !important; }
   </style>
 </head>
 <body>
   <div class="help">
     <h1>muhenkan-switch 使い方</h1>
+
+    <section>
+      <h2>キーボード配列</h2>
+      <p>無変換キーを押しながら使うキーの一覧です。色はカテゴリを表します。</p>
+      <div id="keyboard-svg" style="margin: 12px 0; overflow-x: auto;"></div>
+      <div class="legend">
+        <span class="legend-item"><span class="legend-color lc-folder">&nbsp;</span>フォルダ</span>
+        <span class="legend-item"><span class="legend-color lc-search">&nbsp;</span>検索</span>
+        <span class="legend-item"><span class="legend-color lc-app">&nbsp;</span>アプリ</span>
+        <span class="legend-item"><span class="legend-color lc-ts">&nbsp;</span>タイムスタンプ</span>
+        <span class="legend-item"><span class="legend-color lc-edit">&nbsp;</span>テキスト編集</span>
+        <span class="legend-item"><span class="legend-color lc-unset">&nbsp;</span>未設定</span>
+        <span class="legend-item"><span class="legend-color lc-unused">&nbsp;</span>未使用</span>
+      </div>
+    </section>
 
     <section>
       <h2>概要</h2>
@@ -97,6 +123,14 @@
     if (install) {
       document.querySelectorAll("[data-install]").forEach(el => {
         if (el.dataset.install !== install) el.style.display = "none";
+      });
+    }
+    // キーボード配列 SVG を Tauri 経由で取得して埋め込む
+    if (window.__TAURI__) {
+      window.__TAURI__.core.invoke("generate_keyboard_svg").then(svg => {
+        document.getElementById("keyboard-svg").innerHTML = svg;
+      }).catch(err => {
+        document.getElementById("keyboard-svg").textContent = "キーボード図の読み込みに失敗しました: " + err;
       });
     }
   </script>

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -23,6 +23,12 @@ pub fn get_config() -> Result<Config, String> {
 }
 
 #[tauri::command]
+pub fn generate_keyboard_svg() -> Result<String, String> {
+    let cfg = config::load().map_err(|e| e.to_string())?;
+    Ok(config::svg::generate(&cfg))
+}
+
+#[tauri::command]
 pub fn save_config(config: Config) -> Result<(), String> {
     let errors = config::validate(&config);
     if !errors.is_empty() {

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -29,13 +29,16 @@ pub fn generate_keyboard_svg() -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn save_config(config: Config) -> Result<(), String> {
+pub fn save_config(app: tauri::AppHandle, config: Config) -> Result<(), String> {
+    use tauri::Emitter;
     let errors = config::validate(&config);
     if !errors.is_empty() {
         return Err(errors.join("\n"));
     }
     let path = resolve_config_path();
-    config::save(&path, &config).map_err(|e| e.to_string())
+    config::save(&path, &config).map_err(|e| e.to_string())?;
+    let _ = app.emit("config-saved", ());
+    Ok(())
 }
 
 #[tauri::command]

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -410,10 +410,82 @@ pub fn open_help_window(app: tauri::AppHandle) -> Result<(), String> {
         let url = format!("help.html?install={}", install_type);
         let _ = WebviewWindowBuilder::new(&app, "help", WebviewUrl::App(url.into()))
             .title("使い方 — muhenkan-switch")
-            .inner_size(600.0, 700.0)
+            .inner_size(850.0, 750.0)
             .resizable(true)
             .center()
             .build();
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub fn open_keyboard_window(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri::Manager;
+    if let Some(win) = app.get_webview_window("keyboard") {
+        let _ = win.set_focus();
+        return Ok(());
+    }
+    let cfg = config::load().map_err(|e| e.to_string())?;
+    let svg = config::svg::generate(&cfg);
+    std::thread::spawn(move || {
+        use tauri::{WebviewUrl, WebviewWindowBuilder};
+        let html = format!(
+            r##"<!DOCTYPE html>
+<html><head><meta charset="UTF-8">
+<style>
+body {{ margin:0; background:#1e1e2e; overflow:hidden; width:100vw; height:100vh; cursor:grab; user-select:none; }}
+body.dragging {{ cursor:grabbing; }}
+#wrap {{ transform-origin:0 0; padding:20px; display:inline-block; }}
+</style></head>
+<body>
+<div id="wrap">{svg}</div>
+<script>
+let scale = 1, tx = 0, ty = 0;
+const wrap = document.getElementById("wrap");
+function apply() {{
+  wrap.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+}}
+// ホイールでズーム（Ctrl 不要）
+document.addEventListener("wheel", e => {{
+  e.preventDefault();
+  const old = scale;
+  scale = Math.min(5, Math.max(0.3, scale * (e.deltaY < 0 ? 1.1 : 0.9)));
+  // マウス位置を中心にズーム
+  const r = scale / old;
+  tx = e.clientX - r * (e.clientX - tx);
+  ty = e.clientY - r * (e.clientY - ty);
+  apply();
+}}, {{ passive: false }});
+// ドラッグで移動
+let dragging = false, sx = 0, sy = 0;
+document.addEventListener("mousedown", e => {{
+  if (e.button === 0) {{ dragging = true; sx = e.clientX - tx; sy = e.clientY - ty; document.body.classList.add("dragging"); }}
+}});
+document.addEventListener("mousemove", e => {{
+  if (dragging) {{ tx = e.clientX - sx; ty = e.clientY - sy; apply(); }}
+}});
+document.addEventListener("mouseup", () => {{
+  dragging = false; document.body.classList.remove("dragging");
+}});
+// Ctrl+0 でリセット
+document.addEventListener("keydown", e => {{
+  if (e.ctrlKey && e.key === "0") {{ e.preventDefault(); scale = 1; tx = 0; ty = 0; apply(); }}
+}});
+</script>
+</body></html>"##
+        );
+        let url = WebviewUrl::App("about:blank".into());
+        if let Ok(win) = WebviewWindowBuilder::new(&app, "keyboard", url)
+            .title("キーボード配列 — muhenkan-switch")
+            .inner_size(800.0, 340.0)
+            .resizable(true)
+            .center()
+            .build()
+        {
+            // HTML を直接評価して表示
+            let escaped = html.replace('\\', "\\\\").replace('`', "\\`");
+            let _ = win.eval(&format!("document.open();document.write(`{escaped}`);document.close();"));
+        }
     });
     Ok(())
 }

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
         .manage(kanata::KanataManager::new())
         .invoke_handler(tauri::generate_handler![
             commands::get_config,
+            commands::generate_keyboard_svg,
             commands::save_config,
             commands::reset_config,
             commands::default_config,

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -57,6 +57,7 @@ fn main() {
             commands::open_install_dir,
             commands::open_config_in_editor,
             commands::open_help_window,
+            commands::open_keyboard_window,
             commands::validate_timestamp_format,
             commands::check_update,
             commands::install_update,


### PR DESCRIPTION
## Summary
Closes #29

- `muhenkan-switch-config` に `svg` モジュールを追加。`config.toml` からキーボード配列図 SVG を動的に生成
- `muhenkan-switch-core` に `generate-svg` CLI サブコマンドを追加（`--output`, `--config` オプション）
- ヘルプウィンドウにキーボード配列図セクションを追加（凡例付き）
- 配列図はホイールでズーム、ドラッグで移動、ダブルクリックでリセット
- 設定を「適用」すると、開いているヘルプのキーボード図が自動更新

### カテゴリ色分け
| カテゴリ | 色 |
|---------|-----|
| フォルダ | 黄 `#fff2cc` |
| 検索 | 橙 `#ffe6cc` |
| アプリ | 赤 `#f8cecc` |
| タイムスタンプ | 紫 `#e1d5e7` |
| テキスト編集 | 青 `#dae8fc` |
| 未設定 | 薄灰 `#f5f5f5` |
| 未使用 | 濃灰 `#d9d9d9` |

## Test plan
- [x] `cargo run -p muhenkan-switch-core -- generate-svg --config config/default-windows.toml -o keyboard.svg` で SVG が正しく生成される
- [x] ヘルプウィンドウにキーボード配列図と凡例が表示される
- [x] ホイールでズーム、ドラッグでパン、ダブルクリックでリセットが動作する
- [x] 設定画面でキー割り当てを変更→適用→ヘルプの配列図が自動更新される
- [x] `cargo test -p muhenkan-switch-config` が通る（svg モジュールのユニットテスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)