### PR TITLE
refactor: フォルダキー5 の trash 特殊処理を廃止し home に統一

### DIFF
--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -26,8 +26,8 @@ desktop   = {key = "2", path = "~/Desktop"}
 documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
 project   = {key = "4", path = "~/repos"}
-# trash は OS によりパスが異なります。空欄の場合はデフォルト動作（~/.local/share/Trash/files）
-trash     = {key = "5", path = ""}
+# ↓ お好みのフォルダに変更してお使いください
+home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -26,8 +26,8 @@ desktop   = {key = "2", path = "~/Desktop"}
 documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
 project   = {key = "4", path = "~/repos"}
-# trash は OS によりパスが異なります。空欄の場合はデフォルト動作
-trash     = {key = "5", path = ""}
+# ↓ お好みのフォルダに変更してお使いください
+home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -26,8 +26,8 @@ desktop   = {key = "2", path = "~/Desktop"}
 documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
 project   = {key = "4", path = "~/repos"}
-# trash は OS によりパスが異なります。空欄の場合はデフォルト動作
-trash     = {key = "5", path = ""}
+# ↓ お好みのフォルダに変更してお使いください
+home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）

--- a/config/default.toml
+++ b/config/default.toml
@@ -26,8 +26,8 @@ desktop   = {key = "2", path = "~/Desktop"}
 documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
 project   = {key = "4", path = "~/repos"}
-# trash は OS によりパスが異なります。空欄の場合はデフォルト動作
-trash     = {key = "5", path = ""}
+# ↓ お好みのフォルダに変更してお使いください
+home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # OS 別設定ファイル（default-windows.toml 等）を config.toml としてコピーしてお使いください。

--- a/docs/development.md
+++ b/docs/development.md
@@ -155,7 +155,7 @@ cargo test --workspace
 
 **CLI crate (muhenkan-switch-core):**
 - **timestamp** (`test_compose_*`, `test_resolve_*`) — タイムスタンプ結合・アクション解決の純粋ロジック
-- **open_folder** — `expand_home` のチルダ展開、`resolve_trash_path` のパス解決、存在しないフォルダのエラー
+- **open_folder** — `expand_home` のチルダ展開、存在しないフォルダのエラー、空パスのエラー
 - **switch_app** — `try_wmctrl`/`try_xdotool` が存在しないアプリでパニックしないこと、`activate_window` のエラーハンドリング
 - **toast** — `Toast::show`/`finish` が notify-send 不在でもパニックしないこと、日本語メッセージ対応
 

--- a/muhenkan-switch-core/src/commands/open_folder.rs
+++ b/muhenkan-switch-core/src/commands/open_folder.rs
@@ -7,8 +7,7 @@ pub fn run(target: &str, config: &Config) -> Result<()> {
     let path_str = config::get_folder_path(&config.folders, target)?;
 
     if path_str.is_empty() {
-        // パスが空の場合（ゴミ箱など）、OS ごとのデフォルト動作にフォールバック
-        return open_platform_default(target);
+        anyhow::bail!("Folder '{}' has no path configured in config.toml", target);
     }
 
     // ~ をホームディレクトリに展開
@@ -20,21 +19,6 @@ pub fn run(target: &str, config: &Config) -> Result<()> {
 
     open::that(&path)?;
     Ok(())
-}
-
-/// パスが空のフォルダエントリに対して、OS ごとのデフォルト動作でフォルダを開く。
-fn open_platform_default(target: &str) -> Result<()> {
-    match target {
-        "trash" => {
-            let path = imp::resolve_trash_path()?;
-            open::that(&path)?;
-            Ok(())
-        }
-        _ => anyhow::bail!(
-            "Folder '{}' is not configured in config.toml (empty value)",
-            target
-        ),
-    }
 }
 
 /// "~" または "~/" で始まるパスをホームディレクトリに展開する
@@ -49,63 +33,6 @@ fn expand_home(path_str: &str) -> PathBuf {
         }
     }
     PathBuf::from(path_str)
-}
-
-// ── Platform: Windows ──
-
-#[cfg(target_os = "windows")]
-mod imp {
-    use anyhow::Result;
-    use std::path::PathBuf;
-
-    pub(super) fn resolve_trash_path() -> Result<PathBuf> {
-        // Windows: shell:RecycleBinFolder を explorer.exe で開く
-        // open::that では開けないため、直接 explorer を起動
-        use std::process::Command;
-        Command::new("explorer.exe")
-            .arg("shell:RecycleBinFolder")
-            .spawn()?;
-        // ダミーパスを返す（呼び出し元では使われない）
-        // TODO: open::that("shell:RecycleBinFolder") が動くか検証
-        anyhow::bail!("Opened via explorer.exe")
-    }
-}
-
-// ── Platform: Linux ──
-
-#[cfg(target_os = "linux")]
-mod imp {
-    use anyhow::Result;
-    use std::path::PathBuf;
-
-    pub(super) fn resolve_trash_path() -> Result<PathBuf> {
-        // FreeDesktop Trash Spec: ~/.local/share/Trash/files
-        if let Some(data_local) = dirs::data_local_dir() {
-            let trash = data_local.join("Trash").join("files");
-            if trash.exists() {
-                return Ok(trash);
-            }
-        }
-        anyhow::bail!("Trash folder not found. Set [folders] trash path in config.toml")
-    }
-}
-
-// ── Platform: macOS ──
-
-#[cfg(target_os = "macos")]
-mod imp {
-    use anyhow::Result;
-    use std::path::PathBuf;
-
-    pub(super) fn resolve_trash_path() -> Result<PathBuf> {
-        if let Some(home) = dirs::home_dir() {
-            let trash = home.join(".Trash");
-            if trash.exists() {
-                return Ok(trash);
-            }
-        }
-        anyhow::bail!("Trash folder not found. Set [folders] trash path in config.toml")
-    }
 }
 
 // ── Tests ──
@@ -149,56 +76,12 @@ mod tests {
         assert_eq!(result, PathBuf::from("foo/~/bar"));
     }
 
-    // ── resolve_trash_path ──
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn resolve_trash_path_returns_freedesktop_path() {
-        // Ubuntu にはゴミ箱フォルダがあるはず
-        match imp::resolve_trash_path() {
-            Ok(path) => {
-                assert!(path.exists());
-                assert!(
-                    path.to_string_lossy().contains("Trash/files"),
-                    "Expected path to contain 'Trash/files', got: {}",
-                    path.display()
-                );
-            }
-            Err(e) => {
-                // Trash フォルダが存在しない環境（CI 等）ではエラーでも OK
-                assert!(
-                    e.to_string().contains("Trash folder not found"),
-                    "Unexpected error: {}",
-                    e
-                );
-            }
-        }
-    }
-
-    // ── open_platform_default ──
-
-    #[test]
-    fn open_platform_default_unknown_target_errors() {
-        let result = open_platform_default("nonexistent_folder");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("nonexistent_folder"),
-            "Expected error to mention target name, got: {}",
-            msg
-        );
-        assert!(
-            msg.contains("empty value"),
-            "Expected error to mention empty value, got: {}",
-            msg
-        );
-    }
-
     // ── run (統合テスト) ──
 
     #[test]
     fn run_missing_folder_errors() {
         let config = Config {
+            punctuation_style: "、。".to_string(),
             search: Default::default(),
             folders: Default::default(),
             apps: Default::default(),
@@ -222,6 +105,7 @@ mod tests {
             },
         );
         let config = Config {
+            punctuation_style: "、。".to_string(),
             search: Default::default(),
             folders,
             apps: Default::default(),
@@ -245,6 +129,7 @@ mod tests {
             },
         );
         let config = Config {
+            punctuation_style: "、。".to_string(),
             search: Default::default(),
             folders,
             apps: Default::default(),
@@ -252,6 +137,6 @@ mod tests {
         };
         let result = run("unknown", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("empty value"));
+        assert!(result.unwrap_err().to_string().contains("no path configured"));
     }
 }

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -401,6 +401,7 @@ mod tests {
     #[test]
     fn run_missing_app_errors() {
         let config = Config {
+            punctuation_style: "、。".to_string(),
             search: Default::default(),
             folders: Default::default(),
             apps: Default::default(),


### PR DESCRIPTION
## Summary
- フォルダキー5 の `trash` 特殊処理（`resolve_trash_path` / `open_platform_default`）を削除し、1〜4 と同じ「パスを設定して開く」方式に統一
- デフォルト設定を `trash = {key = "5", path = ""}` → `home = {key = "5", path = "~"}` に全 OS で変更
- 空パスの場合はフォールバックせず明確なエラーメッセージを返すように変更
- テストの `punctuation_style` フィールド欠落も修正

## Test plan
- [x] `cargo test -p muhenkan-switch-core` — 9 tests passed
- [x] `cargo build -p muhenkan-switch-core -p muhenkan-switch-config` — ビルド通過
- [x] 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)