### PR TITLE
feat: デフォルトキー配置の見直しとエントリ名の日本語化

### DIFF
--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -11,38 +11,38 @@ punctuation_style = "、。"
 # key: ディスパッチキー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-google    = {key = "g", url = "https://www.google.com/search?q={query}"}
-ejje      = {key = "q", url = "https://ejje.weblio.jp/content/{query}"}
-thesaurus = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
-deepl     = {key = "w", url = "https://www.deepl.com/translator#auto/ja/{query}"}
-chatgpt   = {key = "b", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
+ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
+Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
 # key: ディスパッチキー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
-downloads = {key = "1", path = "~/Downloads"}
-desktop   = {key = "2", path = "~/Desktop"}
-documents = {key = "3", path = "~/Documents"}
+Downloads = {key = "1", path = "~/Downloads"}
+Desktop   = {key = "2", path = "~/Desktop"}
+Documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
-project   = {key = "4", path = "~/repos"}
+Project   = {key = "4", path = "~/repos"}
 # ↓ お好みのフォルダに変更してお使いください
-home      = {key = "5", path = "~"}
+Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
-browser  = {key = "f", process = "firefox",          command = "firefox"}
-editor   = {key = "a", process = "code",             command = "code"}
-terminal = {key = "t", process = "gnome-terminal",   command = "gnome-terminal"}
-slack    = {key = "s", process = "Slack",              command = "slack"}
-nautilus = {key = "e", process = "org.gnome.Nautilus", command = "nautilus"}
-# ↓ `d` キーはお好みのアプリを設定してください（Document 系がおすすめ）
+"エディタ"    = {key = "a", process = "code",           command = "code"}
+"ブラウザ"    = {key = "f", process = "firefox",        command = "firefox"}
+slack         = {key = "s", process = "Slack",          command = "slack"}
+"ターミナル"  = {key = "w", process = "gnome-terminal", command = "gnome-terminal"}
+# ↓ `d` キーはお好みのアプリを設定してください
 # obsidian    = {key = "d", process = "obsidian",      command = "obsidian"}                             # ノート（Obsidian）
 # notion      = {key = "d", process = "Notion",        command = "notion-app"}                           # ノート（Notion、要インストール）
 # libreoffice = {key = "d", process = "soffice",       command = "libreoffice --writer"}                 # 文書（LibreOffice Writer）
+# discord     = {key = "d", process = "Discord",       command = "discord"}                              # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -11,38 +11,38 @@ punctuation_style = "、。"
 # key: ディスパッチキー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-google    = {key = "g", url = "https://www.google.com/search?q={query}"}
-ejje      = {key = "q", url = "https://ejje.weblio.jp/content/{query}"}
-thesaurus = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
-deepl     = {key = "w", url = "https://www.deepl.com/translator#auto/ja/{query}"}
-chatgpt   = {key = "b", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
+ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
+Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
 # key: ディスパッチキー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
-downloads = {key = "1", path = "~/Downloads"}
-desktop   = {key = "2", path = "~/Desktop"}
-documents = {key = "3", path = "~/Documents"}
+Downloads = {key = "1", path = "~/Downloads"}
+Desktop   = {key = "2", path = "~/Desktop"}
+Documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
-project   = {key = "4", path = "~/repos"}
+Project   = {key = "4", path = "~/repos"}
 # ↓ お好みのフォルダに変更してお使いください
-home      = {key = "5", path = "~"}
+Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
-browser  = {key = "f", process = "Safari",             command = "open -a Safari"}
-editor   = {key = "a", process = "Visual Studio Code", command = "code"}
-terminal = {key = "t", process = "Terminal",            command = "open -a Terminal"}
-slack    = {key = "s", process = "Slack",               command = "open -a Slack"}
-finder   = {key = "e", process = "Finder",              command = "open -a Finder"}
-# ↓ `d` キーはお好みのアプリを設定してください（Document 系がおすすめ）
+"エディタ"    = {key = "a", process = "Visual Studio Code", command = "code"}
+"ブラウザ"    = {key = "f", process = "Safari",             command = "open -a Safari"}
+slack         = {key = "s", process = "Slack",               command = "open -a Slack"}
+"ターミナル"  = {key = "w", process = "Terminal",            command = "open -a Terminal"}
+# ↓ `d` キーはお好みのアプリを設定してください
 # obsidian = {key = "d", process = "Obsidian",          command = "open -a Obsidian"}              # ノート（Obsidian）
 # notion   = {key = "d", process = "Notion",            command = "open -a Notion"}                # ノート（Notion）
 # word     = {key = "d", process = "Microsoft Word",    command = "open -a 'Microsoft Word'"}      # 文書（Word）
+# discord  = {key = "d", process = "Discord",           command = "open -a Discord"}               # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -11,38 +11,38 @@ punctuation_style = "、。"
 # key: ディスパッチキー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-google    = {key = "g", url = "https://www.google.com/search?q={query}"}
-ejje      = {key = "q", url = "https://ejje.weblio.jp/content/{query}"}
-thesaurus = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
-deepl     = {key = "w", url = "https://www.deepl.com/translator#auto/ja/{query}"}
-chatgpt   = {key = "b", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
+ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
+Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
 # key: ディスパッチキー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
-downloads = {key = "1", path = "~/Downloads"}
-desktop   = {key = "2", path = "~/Desktop"}
-documents = {key = "3", path = "~/Documents"}
+Downloads = {key = "1", path = "~/Downloads"}
+Desktop   = {key = "2", path = "~/Desktop"}
+Documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
-project   = {key = "4", path = "~/repos"}
+Project   = {key = "4", path = "~/repos"}
 # ↓ お好みのフォルダに変更してお使いください
-home      = {key = "5", path = "~"}
+Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # key: ディスパッチキー（無変換+key で発動）
 # process: プロセス名（.exe 不要）。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
-browser  = {key = "f", process = "msedge",         command = "msedge"}
-editor   = {key = "a", process = "Code",            command = "code"}
-terminal = {key = "t", process = "WindowsTerminal", command = "wt"}
-slack    = {key = "s", process = "slack",            command = "slack"}
-explorer = {key = "e", process = "explorer",         command = "explorer"}
-# ↓ `d` キーはお好みのアプリを設定してください（Document 系がおすすめ）
+"エディタ" = {key = "a", process = "Code",            command = "code"}
+"ブラウザ" = {key = "f", process = "msedge",           command = "msedge"}
+slack      = {key = "s", process = "slack",            command = "slack"}
+WinTerm    = {key = "w", process = "WindowsTerminal", command = "wt"}
+# ↓ `d` キーはお好みのアプリを設定してください
 # obsidian = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
 # notion   = {key = "d", process = "Notion",          command = "notion"}            # ノート（Notion）
 # word     = {key = "d", process = "WINWORD",         command = "winword"}           # 文書（Word）
+# discord  = {key = "d", process = "Discord",         command = "discord"}           # チャット（Discord）
 # ↓ `z` キーはお好みのアプリを設定してください
 # zoom     = {key = "z", process = "Zoom",             command = "zoom"}              # ビデオ会議（Zoom）
 # zed      = {key = "z", process = "Zed",              command = "zed"}               # エディタ（Zed）

--- a/config/default.toml
+++ b/config/default.toml
@@ -11,23 +11,23 @@ punctuation_style = "、。"
 # key: ディスパッチキー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-google    = {key = "g", url = "https://www.google.com/search?q={query}"}
-ejje      = {key = "q", url = "https://ejje.weblio.jp/content/{query}"}
-thesaurus = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
-deepl     = {key = "w", url = "https://www.deepl.com/translator#auto/ja/{query}"}
-chatgpt   = {key = "b", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
+ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
+Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
 # key: ディスパッチキー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
-downloads = {key = "1", path = "~/Downloads"}
-desktop   = {key = "2", path = "~/Desktop"}
-documents = {key = "3", path = "~/Documents"}
+Downloads = {key = "1", path = "~/Downloads"}
+Desktop   = {key = "2", path = "~/Desktop"}
+Documents = {key = "3", path = "~/Documents"}
 # ↓ よく使うプロジェクトフォルダに変更してお使いください
-project   = {key = "4", path = "~/repos"}
+Project   = {key = "4", path = "~/repos"}
 # ↓ お好みのフォルダに変更してお使いください
-home      = {key = "5", path = "~"}
+Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # OS 別設定ファイル（default-windows.toml 等）を config.toml としてコピーしてお使いください。
@@ -35,13 +35,14 @@ home      = {key = "5", path = "~"}
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
-browser  = {key = "f", process = "firefox",  command = "firefox"}
-editor   = {key = "a", process = "Code",     command = "code"}
-terminal = {key = "t", process = "terminal", command = "terminal"}
-# ↓ `d` キーはお好みのアプリを設定してください（Document 系がおすすめ）
+"エディタ"    = {key = "a", process = "Code",     command = "code"}
+"ブラウザ"    = {key = "f", process = "firefox",  command = "firefox"}
+"ターミナル"  = {key = "w", process = "terminal", command = "terminal"}
+# ↓ `d` キーはお好みのアプリを設定してください
 # obsidian = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
 # notion   = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
 # word     = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）
+# discord  = {key = "d", process = "Discord",  command = "discord"}    # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -521,7 +521,7 @@ mod tests {
         let config = default_config();
         assert_eq!(config.timestamp.format, "%Y%m%d");
         assert_eq!(config.timestamp.position, "before");
-        assert!(config.search.contains_key("google"));
+        assert!(config.search.contains_key("Google"));
         // OS 別デフォルトが正しくパースされ、全セクションが埋まっていること
         assert!(
             config.search.len() >= 5,

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -289,8 +289,8 @@ mod tests {
     fn test_svg_contains_entry_names() {
         let config = default_config();
         let svg = generate(&config);
-        assert!(svg.contains("google"), "SVG should contain 'google'");
-        assert!(svg.contains("ejje"), "SVG should contain 'ejje'");
+        assert!(svg.contains("Google"), "SVG should contain 'Google'");
+        assert!(svg.contains("英和辞典"), "SVG should contain '英和辞典'");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **検索キー配置変更**: e=英和辞典, g=Google, q=ChatGPT, r=類語辞典, t=Translate（ニーモニック改善）
- **アプリ**: explorer/Finder/nautilus を削除（無変換+数字キーで代替可能）、terminal を `w` に移動して `t` を検索の Translate に割当
- **d/z キー**: ユーザーカスタマイズ枠として整理、discord をコメント例に追加
- **命名統一**: エントリ名を大文字始まり・日本語表記に（GUI 表示・SVG ラベルで見やすく）

## Test plan
- [x] `cargo test -p muhenkan-switch-config` 全 29 テスト通過
- [x] 各 OS のデフォルト設定でキー重複がないことを確認
- [x] GUI のキーボード配列図 SVG で日本語ラベルが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)