### PR TITLE
feat: エラー時のトースト通知とアプリタブUI簡素化

### DIFF
--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -498,7 +498,7 @@ pub fn get_search_url<'a>(
     search
         .get(engine)
         .map(|e| e.url())
-        .ok_or_else(|| anyhow::anyhow!("Search engine '{}' is not defined in config.toml", engine))
+        .ok_or_else(|| anyhow::anyhow!("検索エンジン '{}' が config.toml に定義されていません", engine))
 }
 
 /// フォルダのパスを取得する。
@@ -509,7 +509,7 @@ pub fn get_folder_path<'a>(
     folders
         .get(target)
         .map(|e| e.path())
-        .ok_or_else(|| anyhow::anyhow!("Folder '{}' is not defined in config.toml", target))
+        .ok_or_else(|| anyhow::anyhow!("フォルダ '{}' が config.toml に定義されていません", target))
 }
 
 #[cfg(test)]

--- a/muhenkan-switch-core/src/commands/open_folder.rs
+++ b/muhenkan-switch-core/src/commands/open_folder.rs
@@ -7,14 +7,14 @@ pub fn run(target: &str, config: &Config) -> Result<()> {
     let path_str = config::get_folder_path(&config.folders, target)?;
 
     if path_str.is_empty() {
-        anyhow::bail!("Folder '{}' has no path configured in config.toml", target);
+        anyhow::bail!("フォルダ '{}' のパスが config.toml に設定されていません", target);
     }
 
     // ~ をホームディレクトリに展開
     let path = expand_home(path_str);
 
     if !path.exists() {
-        anyhow::bail!("Folder does not exist: {}", path.display());
+        anyhow::bail!("フォルダが見つかりません: {}", path.display());
     }
 
     open::that(&path)?;
@@ -89,7 +89,7 @@ mod tests {
         };
         let result = run("nonexistent", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not defined"));
+        assert!(result.unwrap_err().to_string().contains("定義されていません"));
     }
 
     #[test]
@@ -113,7 +113,7 @@ mod tests {
         };
         let result = run("test", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not exist"));
+        assert!(result.unwrap_err().to_string().contains("見つかりません"));
     }
 
     #[test]
@@ -137,6 +137,6 @@ mod tests {
         };
         let result = run("unknown", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("no path configured"));
+        assert!(result.unwrap_err().to_string().contains("設定されていません"));
     }
 }

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -2,18 +2,26 @@ use anyhow::Result;
 #[cfg(not(target_os = "windows"))]
 use std::process::Command;
 
+use super::toast::Toast;
 use crate::config::Config;
 
 pub fn run(target: &str, config: &Config) -> Result<()> {
     let entry = config
         .apps
         .get(target)
-        .ok_or_else(|| anyhow::anyhow!("App '{}' is not defined in config.toml", target))?;
+        .ok_or_else(|| anyhow::anyhow!("アプリ '{}' が config.toml に定義されていません", target))?;
 
     let process_name = entry.process();
     let command = entry.command();
 
     imp::activate_window(process_name, command)
+}
+
+/// プロセスが見つからず launch コマンドも未設定の場合に Toast で通知する。
+fn notify_process_not_found(app: &str) {
+    let msg = format!("'{}' が見つかりません — config.toml の command を設定してください", app);
+    let toast = Toast::show(&msg);
+    toast.finish(&msg);
 }
 
 // ── Platform: Windows ──
@@ -74,9 +82,11 @@ mod imp {
         }
 
         if pids.is_empty() {
-            // Process not found — launch if configured
+            // Process not found — launch if configured, otherwise notify
             if let Some(cmd) = launch {
                 shell_execute(cmd)?;
+            } else {
+                notify_process_not_found(app);
             }
             return Ok(());
         }
@@ -113,9 +123,11 @@ mod imp {
         let hwnd = match data.hwnd {
             Some(h) => h,
             None => {
-                // Window not found — launch if configured
+                // Window not found — launch if configured, otherwise notify
                 if let Some(cmd) = launch {
                     shell_execute(cmd)?;
+                } else {
+                    notify_process_not_found(app);
                 }
                 return Ok(());
             }
@@ -258,14 +270,12 @@ mod imp {
             || try_xdotool(app, "--name");
 
         if !activated {
-            eprintln!(
-                "Warning: Wayland ではウィンドウのアクティブ化ができません。\
-                 X11 セッション（「Ubuntu on Xorg」）への切り替えを推奨します。"
-            );
             if let Some(cmd) = launch {
                 if let Err(e) = Command::new("sh").args(["-c", cmd]).spawn() {
                     eprintln!("Warning: failed to launch '{}': {}", cmd, e);
                 }
+            } else {
+                notify_process_not_found(app);
             }
         }
 
@@ -286,6 +296,8 @@ mod imp {
                 if let Err(e) = Command::new("sh").args(["-c", cmd]).spawn() {
                     eprintln!("Warning: failed to launch '{}': {}", cmd, e);
                 }
+            } else {
+                notify_process_not_found(app);
             }
         }
 
@@ -409,6 +421,6 @@ mod tests {
         };
         let result = run("nonexistent", &config);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not defined"));
+        assert!(result.unwrap_err().to_string().contains("定義されていません"));
     }
 }

--- a/muhenkan-switch-core/src/commands/toast.rs
+++ b/muhenkan-switch-core/src/commands/toast.rs
@@ -237,16 +237,35 @@ mod imp {
 
 #[cfg(target_os = "macos")]
 mod imp {
-    /// macOS: トースト通知は未実装 (no-op)。
-    /// osascript の `display notification` や terminal-notifier で実装可能。
+    use std::process::Command;
+
     pub struct Toast;
 
     impl Toast {
-        pub fn show(_initial_message: &str) -> Self {
+        pub fn show(initial_message: &str) -> Self {
+            let _ = Command::new("osascript")
+                .args([
+                    "-e",
+                    &format!(
+                        r#"display notification "{}" with title "muhenkan-switch""#,
+                        initial_message.replace('"', r#"\""#)
+                    ),
+                ])
+                .spawn();
             Toast
         }
 
-        pub fn finish(self, _message: &str) {}
+        pub fn finish(self, message: &str) {
+            let _ = Command::new("osascript")
+                .args([
+                    "-e",
+                    &format!(
+                        r#"display notification "{}" with title "muhenkan-switch""#,
+                        message.replace('"', r#"\""#)
+                    ),
+                ])
+                .spawn();
+        }
     }
 }
 

--- a/muhenkan-switch-core/src/main.rs
+++ b/muhenkan-switch-core/src/main.rs
@@ -4,6 +4,8 @@ use clap::{Parser, Subcommand};
 mod commands;
 mod config;
 
+use commands::toast::Toast;
+
 #[derive(Parser)]
 #[command(
     name = "muhenkan-switch-core",
@@ -59,7 +61,16 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = run() {
+        let msg = format!("{e:#}");
+        eprintln!("Error: {msg}");
+        let toast = Toast::show(&msg);
+        toast.finish(&msg);
+    }
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
 
     // config 不要なコマンドは先に処理

--- a/muhenkan-switch/frontend/index.html
+++ b/muhenkan-switch/frontend/index.html
@@ -134,7 +134,7 @@
       <!-- Apps -->
       <div class="panel" id="panel-apps">
         <h2>アプリ切り替え</h2>
-        <p class="hint">プロセス名（拡張子不要）。実行コマンドはアプリ未起動時の起動に使用します。</p>
+        <p class="hint">プロセス名。選択ボタンで実行中のプロセスから選べます。</p>
         <div class="dynamic-list" id="apps-list"></div>
         <button class="btn-add" id="btn-add-app">+ 追加</button>
       </div>

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -259,9 +259,9 @@ function addAppRow(container, name = "", process = "", command = "", dispatchKey
   const row = document.createElement("div");
   row.className = "list-row";
   row.innerHTML = `
-    <input type="text" class="key-input" placeholder="キー" value="${escapeHtml(name)}">
-    <input type="text" class="process-input" placeholder="プロセス名" value="${escapeHtml(process)}">
-    <input type="text" class="command-input" placeholder="実行コマンド" value="${escapeHtml(command)}">
+    <input type="text" class="key-input" placeholder="名前" value="${escapeHtml(name)}">
+    <input type="text" class="process-input" placeholder="プロセス名" value="${escapeHtml(process)}" readonly>
+    <input type="hidden" class="command-input" value="${escapeHtml(command)}">
     <button class="btn-pick-process" title="プロセス選択">選択</button>
     <button class="btn-remove" title="削除">&times;</button>
   `;

--- a/muhenkan-switch/frontend/styles/main.css
+++ b/muhenkan-switch/frontend/styles/main.css
@@ -140,6 +140,11 @@ select:focus {
   border-color: var(--accent);
 }
 
+input[type="text"][readonly] {
+  opacity: 0.7;
+  cursor: default;
+}
+
 .checkbox-label,
 .radio-label {
   display: flex;


### PR DESCRIPTION
## Summary
- core バイナリのエラーをトップレベルでキャッチし Toast で通知（kanata 経由でも見える）
- switch_app でプロセス未検出 & launch 未設定時に Toast で案内メッセージ表示
- macOS の Toast 実装を追加（osascript display notification）
- エラーメッセージを日本語に統一
- アプリタブの実行コマンド列を非表示化（値は hidden で保持、config.toml 直接編集で変更可能）
- プロセス名フィールドを readonly に変更（選択ボタンからのみ設定）

## Test plan
- [x] `cargo test -p muhenkan-switch-config -p muhenkan-switch-core` 全テスト通過
- [x] `muhenkan-switch-core open-folder --target nonexistent` → Toast 表示確認
- [x] `muhenkan-switch-core switch-app --target nonexistent` → Toast 表示確認
- [x] アプリタブでプロセス名が readonly、選択ボタンから設定できること確認
- [x] 既存の command 値が保持されていること確認（config.toml で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)