### PR TITLE
feat: config UI 改善（用語統一・アプリプルダウン化・SVG 表示改善）

### DIFF
--- a/config/app-presets.json
+++ b/config/app-presets.json
@@ -1,0 +1,86 @@
+{
+  "windows": {
+    "エディタ": [
+      { "label": "VS Code", "process": "Code", "command": "code" },
+      { "label": "Cursor", "process": "Cursor", "command": "cursor" },
+      { "label": "Zed", "process": "Zed", "command": "zed" }
+    ],
+    "ブラウザ": [
+      { "label": "Edge", "process": "msedge", "command": "msedge" },
+      { "label": "Chrome", "process": "chrome", "command": "chrome" },
+      { "label": "Firefox", "process": "firefox", "command": "firefox" },
+      { "label": "Zen", "process": "zen", "command": "zen" }
+    ],
+    "ドキュメント": [
+      { "label": "OneNote", "process": "OneNote", "command": "onenote" },
+      { "label": "Obsidian", "process": "Obsidian", "command": "obsidian" },
+      { "label": "Notion", "process": "Notion", "command": "notion" },
+      { "label": "Word", "process": "WINWORD", "command": "winword" }
+    ],
+    "チャット": [
+      { "label": "Slack", "process": "slack", "command": "slack" },
+      { "label": "Discord", "process": "Discord", "command": "discord" },
+      { "label": "Teams", "process": "ms-teams", "command": "ms-teams" }
+    ],
+    "ターミナル": [
+      { "label": "Windows Terminal", "process": "WindowsTerminal", "command": "wt" },
+      { "label": "Alacritty", "process": "alacritty", "command": "alacritty" }
+    ]
+  },
+  "macos": {
+    "エディタ": [
+      { "label": "VS Code", "process": "Visual Studio Code", "command": "code" },
+      { "label": "Cursor", "process": "Cursor", "command": "open -a Cursor" },
+      { "label": "Zed", "process": "Zed", "command": "open -a Zed" }
+    ],
+    "ブラウザ": [
+      { "label": "Safari", "process": "Safari", "command": "open -a Safari" },
+      { "label": "Chrome", "process": "Google Chrome", "command": "open -a 'Google Chrome'" },
+      { "label": "Firefox", "process": "firefox", "command": "open -a Firefox" },
+      { "label": "Zen", "process": "zen", "command": "open -a 'Zen Browser'" }
+    ],
+    "ドキュメント": [
+      { "label": "OneNote", "process": "Microsoft OneNote", "command": "open -a 'Microsoft OneNote'" },
+      { "label": "Obsidian", "process": "Obsidian", "command": "open -a Obsidian" },
+      { "label": "Notion", "process": "Notion", "command": "open -a Notion" },
+      { "label": "Word", "process": "Microsoft Word", "command": "open -a 'Microsoft Word'" }
+    ],
+    "チャット": [
+      { "label": "Slack", "process": "Slack", "command": "open -a Slack" },
+      { "label": "Discord", "process": "Discord", "command": "open -a Discord" },
+      { "label": "Teams", "process": "Microsoft Teams", "command": "open -a 'Microsoft Teams'" }
+    ],
+    "ターミナル": [
+      { "label": "Terminal", "process": "Terminal", "command": "open -a Terminal" },
+      { "label": "iTerm2", "process": "iTerm2", "command": "open -a iTerm" },
+      { "label": "Alacritty", "process": "alacritty", "command": "open -a Alacritty" }
+    ]
+  },
+  "linux": {
+    "エディタ": [
+      { "label": "VS Code", "process": "code", "command": "code" },
+      { "label": "Cursor", "process": "cursor", "command": "cursor" },
+      { "label": "Zed", "process": "zed", "command": "zed" }
+    ],
+    "ブラウザ": [
+      { "label": "Firefox", "process": "firefox", "command": "firefox" },
+      { "label": "Chrome", "process": "google-chrome", "command": "google-chrome" },
+      { "label": "Zen", "process": "zen", "command": "zen" }
+    ],
+    "ドキュメント": [
+      { "label": "OneNote", "process": "onenote", "command": "onenote" },
+      { "label": "Obsidian", "process": "obsidian", "command": "obsidian" },
+      { "label": "Notion", "process": "Notion", "command": "notion-app" },
+      { "label": "LibreOffice Writer", "process": "soffice", "command": "libreoffice --writer" }
+    ],
+    "チャット": [
+      { "label": "Slack", "process": "Slack", "command": "slack" },
+      { "label": "Discord", "process": "Discord", "command": "discord" }
+    ],
+    "ターミナル": [
+      { "label": "GNOME Terminal", "process": "gnome-terminal", "command": "gnome-terminal" },
+      { "label": "Alacritty", "process": "alacritty", "command": "alacritty" },
+      { "label": "Kitty", "process": "kitty", "command": "kitty" }
+    ]
+  }
+}

--- a/config/app-presets.json
+++ b/config/app-presets.json
@@ -11,7 +11,7 @@
       { "label": "Firefox", "process": "firefox", "command": "firefox" },
       { "label": "Zen", "process": "zen", "command": "zen" }
     ],
-    "ドキュメント": [
+    "Document": [
       { "label": "OneNote", "process": "OneNote", "command": "onenote" },
       { "label": "Obsidian", "process": "Obsidian", "command": "obsidian" },
       { "label": "Notion", "process": "Notion", "command": "notion" },
@@ -39,7 +39,7 @@
       { "label": "Firefox", "process": "firefox", "command": "open -a Firefox" },
       { "label": "Zen", "process": "zen", "command": "open -a 'Zen Browser'" }
     ],
-    "ドキュメント": [
+    "Document": [
       { "label": "OneNote", "process": "Microsoft OneNote", "command": "open -a 'Microsoft OneNote'" },
       { "label": "Obsidian", "process": "Obsidian", "command": "open -a Obsidian" },
       { "label": "Notion", "process": "Notion", "command": "open -a Notion" },
@@ -67,7 +67,7 @@
       { "label": "Chrome", "process": "google-chrome", "command": "google-chrome" },
       { "label": "Zen", "process": "zen", "command": "zen" }
     ],
-    "ドキュメント": [
+    "Document": [
       { "label": "OneNote", "process": "onenote", "command": "onenote" },
       { "label": "Obsidian", "process": "obsidian", "command": "obsidian" },
       { "label": "Notion", "process": "Notion", "command": "notion-app" },

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -38,7 +38,8 @@ Home      = {key = "5", path = "~"}
 "ブラウザ"    = {key = "f", process = "firefox",        command = "firefox"}
 slack         = {key = "s", process = "Slack",          command = "slack"}
 "ターミナル"  = {key = "w", process = "gnome-terminal", command = "gnome-terminal"}
-# ↓ `d` キーはお好みのアプリを設定してください
+"ドキュメント" = {key = "d", process = "onenote",          command = "onenote"}
+# ↓ `d` キーはお好みのアプリに変更できます
 # "ドキュメント" = {key = "d", process = "obsidian",  command = "obsidian"}              # ノート（Obsidian）
 # "ドキュメント" = {key = "d", process = "Notion",    command = "notion-app"}            # ノート（Notion、要インストール）
 # "ドキュメント" = {key = "d", process = "soffice",   command = "libreoffice --writer"}  # 文書（LibreOffice Writer）

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -39,10 +39,10 @@ Home      = {key = "5", path = "~"}
 slack         = {key = "s", process = "Slack",          command = "slack"}
 "ターミナル"  = {key = "w", process = "gnome-terminal", command = "gnome-terminal"}
 # ↓ `d` キーはお好みのアプリを設定してください
-# obsidian    = {key = "d", process = "obsidian",      command = "obsidian"}                             # ノート（Obsidian）
-# notion      = {key = "d", process = "Notion",        command = "notion-app"}                           # ノート（Notion、要インストール）
-# libreoffice = {key = "d", process = "soffice",       command = "libreoffice --writer"}                 # 文書（LibreOffice Writer）
-# discord     = {key = "d", process = "Discord",       command = "discord"}                              # チャット（Discord）
+# "ドキュメント" = {key = "d", process = "obsidian",  command = "obsidian"}              # ノート（Obsidian）
+# "ドキュメント" = {key = "d", process = "Notion",    command = "notion-app"}            # ノート（Notion、要インストール）
+# "ドキュメント" = {key = "d", process = "soffice",   command = "libreoffice --writer"}  # 文書（LibreOffice Writer）
+# Discord       = {key = "d", process = "Discord",   command = "discord"}              # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -8,17 +8,17 @@
 punctuation_style = "、。"
 
 # ── 検索エンジン ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
-ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
 Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
 Downloads = {key = "1", path = "~/Downloads"}
@@ -30,7 +30,7 @@ Project   = {key = "4", path = "~/repos"}
 Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -11,7 +11,7 @@ punctuation_style = "、。"
 # key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英語辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
 Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -35,8 +35,8 @@ Home      = {key = "5", path = "~"}
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
 "エディタ"    = {key = "a", process = "code",           command = "code"}
-"ブラウザ"    = {key = "f", process = "firefox",        command = "firefox"}
-slack         = {key = "s", process = "Slack",          command = "slack"}
+"ブラウザ (Firefox)" = {key = "f", process = "firefox",  command = "firefox"}
+"チャット (Slack)"  = {key = "s", process = "Slack",    command = "slack"}
 "ターミナル"  = {key = "w", process = "gnome-terminal", command = "gnome-terminal"}
 Document = {key = "d", process = "onenote",          command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -38,11 +38,11 @@ Home      = {key = "5", path = "~"}
 "ブラウザ"    = {key = "f", process = "firefox",        command = "firefox"}
 slack         = {key = "s", process = "Slack",          command = "slack"}
 "ターミナル"  = {key = "w", process = "gnome-terminal", command = "gnome-terminal"}
-"ドキュメント" = {key = "d", process = "onenote",          command = "onenote"}
+Document = {key = "d", process = "onenote",          command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます
-# "ドキュメント" = {key = "d", process = "obsidian",  command = "obsidian"}              # ノート（Obsidian）
-# "ドキュメント" = {key = "d", process = "Notion",    command = "notion-app"}            # ノート（Notion、要インストール）
-# "ドキュメント" = {key = "d", process = "soffice",   command = "libreoffice --writer"}  # 文書（LibreOffice Writer）
+# Document = {key = "d", process = "obsidian",  command = "obsidian"}              # ノート（Obsidian）
+# Document = {key = "d", process = "Notion",    command = "notion-app"}            # ノート（Notion、要インストール）
+# Document = {key = "d", process = "soffice",   command = "libreoffice --writer"}  # 文書（LibreOffice Writer）
 # Discord       = {key = "d", process = "Discord",   command = "discord"}              # チャット（Discord）
 
 # ── タイムスタンプ ──

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -38,11 +38,11 @@ Home      = {key = "5", path = "~"}
 "ブラウザ"    = {key = "f", process = "Safari",             command = "open -a Safari"}
 slack         = {key = "s", process = "Slack",               command = "open -a Slack"}
 "ターミナル"  = {key = "w", process = "Terminal",            command = "open -a Terminal"}
-"ドキュメント" = {key = "d", process = "Microsoft OneNote",  command = "open -a 'Microsoft OneNote'"}
+Document = {key = "d", process = "Microsoft OneNote",  command = "open -a 'Microsoft OneNote'"}
 # ↓ `d` キーはお好みのアプリに変更できます
-# "ドキュメント" = {key = "d", process = "Obsidian",        command = "open -a Obsidian"}         # ノート（Obsidian）
-# "ドキュメント" = {key = "d", process = "Notion",          command = "open -a Notion"}           # ノート（Notion）
-# "ドキュメント" = {key = "d", process = "Microsoft Word",  command = "open -a 'Microsoft Word'"} # 文書（Word）
+# Document = {key = "d", process = "Obsidian",        command = "open -a Obsidian"}         # ノート（Obsidian）
+# Document = {key = "d", process = "Notion",          command = "open -a Notion"}           # ノート（Notion）
+# Document = {key = "d", process = "Microsoft Word",  command = "open -a 'Microsoft Word'"} # 文書（Word）
 # Discord       = {key = "d", process = "Discord",        command = "open -a Discord"}           # チャット（Discord）
 
 # ── タイムスタンプ ──

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -38,7 +38,8 @@ Home      = {key = "5", path = "~"}
 "ブラウザ"    = {key = "f", process = "Safari",             command = "open -a Safari"}
 slack         = {key = "s", process = "Slack",               command = "open -a Slack"}
 "ターミナル"  = {key = "w", process = "Terminal",            command = "open -a Terminal"}
-# ↓ `d` キーはお好みのアプリを設定してください
+"ドキュメント" = {key = "d", process = "Microsoft OneNote",  command = "open -a 'Microsoft OneNote'"}
+# ↓ `d` キーはお好みのアプリに変更できます
 # "ドキュメント" = {key = "d", process = "Obsidian",        command = "open -a Obsidian"}         # ノート（Obsidian）
 # "ドキュメント" = {key = "d", process = "Notion",          command = "open -a Notion"}           # ノート（Notion）
 # "ドキュメント" = {key = "d", process = "Microsoft Word",  command = "open -a 'Microsoft Word'"} # 文書（Word）

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -35,8 +35,8 @@ Home      = {key = "5", path = "~"}
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
 "エディタ"    = {key = "a", process = "Visual Studio Code", command = "code"}
-"ブラウザ"    = {key = "f", process = "Safari",             command = "open -a Safari"}
-slack         = {key = "s", process = "Slack",               command = "open -a Slack"}
+"ブラウザ (Firefox)" = {key = "f", process = "firefox",       command = "open -a Firefox"}
+"チャット (Slack)"  = {key = "s", process = "Slack",         command = "open -a Slack"}
 "ターミナル"  = {key = "w", process = "Terminal",            command = "open -a Terminal"}
 Document = {key = "d", process = "Microsoft OneNote",  command = "open -a 'Microsoft OneNote'"}
 # ↓ `d` キーはお好みのアプリに変更できます

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -8,17 +8,17 @@
 punctuation_style = "、。"
 
 # ── 検索エンジン ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
-ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
 Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
 Downloads = {key = "1", path = "~/Downloads"}
@@ -30,7 +30,7 @@ Project   = {key = "4", path = "~/repos"}
 Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -11,7 +11,7 @@ punctuation_style = "、。"
 # key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英語辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
 Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -39,10 +39,10 @@ Home      = {key = "5", path = "~"}
 slack         = {key = "s", process = "Slack",               command = "open -a Slack"}
 "ターミナル"  = {key = "w", process = "Terminal",            command = "open -a Terminal"}
 # ↓ `d` キーはお好みのアプリを設定してください
-# obsidian = {key = "d", process = "Obsidian",          command = "open -a Obsidian"}              # ノート（Obsidian）
-# notion   = {key = "d", process = "Notion",            command = "open -a Notion"}                # ノート（Notion）
-# word     = {key = "d", process = "Microsoft Word",    command = "open -a 'Microsoft Word'"}      # 文書（Word）
-# discord  = {key = "d", process = "Discord",           command = "open -a Discord"}               # チャット（Discord）
+# "ドキュメント" = {key = "d", process = "Obsidian",        command = "open -a Obsidian"}         # ノート（Obsidian）
+# "ドキュメント" = {key = "d", process = "Notion",          command = "open -a Notion"}           # ノート（Notion）
+# "ドキュメント" = {key = "d", process = "Microsoft Word",  command = "open -a 'Microsoft Word'"} # 文書（Word）
+# Discord       = {key = "d", process = "Discord",        command = "open -a Discord"}           # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -39,14 +39,14 @@ Home      = {key = "5", path = "~"}
 slack      = {key = "s", process = "slack",            command = "slack"}
 WinTerm    = {key = "w", process = "WindowsTerminal", command = "wt"}
 # ↓ `d` キーはお好みのアプリを設定してください
-# obsidian = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
-# notion   = {key = "d", process = "Notion",          command = "notion"}            # ノート（Notion）
-# word     = {key = "d", process = "WINWORD",         command = "winword"}           # 文書（Word）
-# discord  = {key = "d", process = "Discord",         command = "discord"}           # チャット（Discord）
+# "ドキュメント" = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
+# "ドキュメント" = {key = "d", process = "Notion",         command = "notion"}            # ノート（Notion）
+# "ドキュメント" = {key = "d", process = "WINWORD",        command = "winword"}           # 文書（Word）
+# Discord       = {key = "d", process = "Discord",        command = "discord"}           # チャット（Discord）
 # ↓ `z` キーはお好みのアプリを設定してください
-# zoom     = {key = "z", process = "Zoom",             command = "zoom"}              # ビデオ会議（Zoom）
-# zed      = {key = "z", process = "Zed",              command = "zed"}               # エディタ（Zed）
-# zen      = {key = "z", process = "zen",              command = "zen"}               # ブラウザ（Zen Browser）
+# "ビデオ会議"   = {key = "z", process = "Zoom",            command = "zoom"}              # Zoom
+# "エディタ2"    = {key = "z", process = "Zed",             command = "zed"}               # Zed
+# "ブラウザ2"    = {key = "z", process = "zen",             command = "zen"}               # Zen Browser
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -38,7 +38,8 @@ Home      = {key = "5", path = "~"}
 "ブラウザ" = {key = "f", process = "msedge",           command = "msedge"}
 slack      = {key = "s", process = "slack",            command = "slack"}
 WinTerm    = {key = "w", process = "WindowsTerminal", command = "wt"}
-# ↓ `d` キーはお好みのアプリを設定してください
+"ドキュメント" = {key = "d", process = "OneNote",          command = "onenote"}
+# ↓ `d` キーはお好みのアプリに変更できます
 # "ドキュメント" = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
 # "ドキュメント" = {key = "d", process = "Notion",         command = "notion"}            # ノート（Notion）
 # "ドキュメント" = {key = "d", process = "WINWORD",        command = "winword"}           # 文書（Word）

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -11,7 +11,7 @@ punctuation_style = "、。"
 # key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英語辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
 Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -8,17 +8,17 @@
 punctuation_style = "、。"
 
 # ── 検索エンジン ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
-ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+Question   = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
 Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
 Downloads = {key = "1", path = "~/Downloads"}
@@ -30,7 +30,7 @@ Project   = {key = "4", path = "~/repos"}
 Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # process: プロセス名（.exe 不要）。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -38,11 +38,11 @@ Home      = {key = "5", path = "~"}
 "ブラウザ" = {key = "f", process = "msedge",           command = "msedge"}
 slack      = {key = "s", process = "slack",            command = "slack"}
 WinTerm    = {key = "w", process = "WindowsTerminal", command = "wt"}
-"ドキュメント" = {key = "d", process = "OneNote",          command = "onenote"}
+Document = {key = "d", process = "OneNote",          command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます
-# "ドキュメント" = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
-# "ドキュメント" = {key = "d", process = "Notion",         command = "notion"}            # ノート（Notion）
-# "ドキュメント" = {key = "d", process = "WINWORD",        command = "winword"}           # 文書（Word）
+# Document = {key = "d", process = "Obsidian",       command = "obsidian"}          # ノート（Obsidian）
+# Document = {key = "d", process = "Notion",         command = "notion"}            # ノート（Notion）
+# Document = {key = "d", process = "WINWORD",        command = "winword"}           # 文書（Word）
 # Discord       = {key = "d", process = "Discord",        command = "discord"}           # チャット（Discord）
 # ↓ `z` キーはお好みのアプリを設定してください
 # "ビデオ会議"   = {key = "z", process = "Zoom",            command = "zoom"}              # Zoom

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -35,8 +35,8 @@ Home      = {key = "5", path = "~"}
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
 "エディタ" = {key = "a", process = "Code",            command = "code"}
-"ブラウザ" = {key = "f", process = "msedge",           command = "msedge"}
-slack      = {key = "s", process = "slack",            command = "slack"}
+"ブラウザ (Firefox)" = {key = "f", process = "firefox",  command = "firefox"}
+"チャット (Slack)"  = {key = "s", process = "slack",    command = "slack"}
 WinTerm    = {key = "w", process = "WindowsTerminal", command = "wt"}
 Document = {key = "d", process = "OneNote",          command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます

--- a/config/default.toml
+++ b/config/default.toml
@@ -11,7 +11,7 @@ punctuation_style = "、。"
 # key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+"英語辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
 Google    = {key = "g", url = "https://www.google.com/search?q={query}"}
 Question  = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}

--- a/config/default.toml
+++ b/config/default.toml
@@ -36,7 +36,8 @@ Home      = {key = "5", path = "~"}
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
 "エディタ"    = {key = "a", process = "Code",     command = "code"}
-"ブラウザ"    = {key = "f", process = "firefox",  command = "firefox"}
+"ブラウザ (Firefox)" = {key = "f", process = "firefox",  command = "firefox"}
+"チャット (Slack)"  = {key = "s", process = "slack",    command = "slack"}
 "ターミナル"  = {key = "w", process = "terminal", command = "terminal"}
 Document = {key = "d", process = "OneNote",  command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます

--- a/config/default.toml
+++ b/config/default.toml
@@ -8,17 +8,17 @@
 punctuation_style = "、。"
 
 # ── 検索エンジン ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # url: {query} が選択テキスト（URLエンコード済み）に置換されます
 [search]
-"英和辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
-Google     = {key = "g", url = "https://www.google.com/search?q={query}"}
-ChatGPT    = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
+"英和和英辞典" = {key = "e", url = "https://ejje.weblio.jp/content/{query}"}
+Google    = {key = "g", url = "https://www.google.com/search?q={query}"}
+Question  = {key = "q", url = "https://chatgpt.com/?q={query}&temporary-chat=true"}
 "類語辞典" = {key = "r", url = "https://thesaurus.weblio.jp/content/{query}"}
-Translate  = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
+Translate = {key = "t", url = "https://www.deepl.com/translator#auto/ja/{query}"}
 
 # ── フォルダ ──
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # path: ~ はホームディレクトリに展開されます
 [folders]
 Downloads = {key = "1", path = "~/Downloads"}
@@ -31,7 +31,7 @@ Home      = {key = "5", path = "~"}
 
 # ── アプリ切り替え ──
 # OS 別設定ファイル（default-windows.toml 等）を config.toml としてコピーしてお使いください。
-# key: ディスパッチキー（無変換+key で発動）
+# key: 割当キー（無変換+key で発動）
 # process: プロセス名。ウィンドウ検索に使用
 # command: 実行コマンド。アプリ未起動時の起動に使用（省略時は process 名で起動）
 [apps]
@@ -39,10 +39,10 @@ Home      = {key = "5", path = "~"}
 "ブラウザ"    = {key = "f", process = "firefox",  command = "firefox"}
 "ターミナル"  = {key = "w", process = "terminal", command = "terminal"}
 # ↓ `d` キーはお好みのアプリを設定してください
-# obsidian = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
-# notion   = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
-# word     = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）
-# discord  = {key = "d", process = "Discord",  command = "discord"}    # チャット（Discord）
+# "ドキュメント" = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
+# "ドキュメント" = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
+# "ドキュメント" = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）
+# Discord       = {key = "d", process = "Discord",  command = "discord"}    # チャット（Discord）
 
 # ── タイムスタンプ ──
 # V: テキスト入力時は現在日時、エクスプローラー上ではファイル更新日時でリネーム

--- a/config/default.toml
+++ b/config/default.toml
@@ -38,7 +38,8 @@ Home      = {key = "5", path = "~"}
 "エディタ"    = {key = "a", process = "Code",     command = "code"}
 "ブラウザ"    = {key = "f", process = "firefox",  command = "firefox"}
 "ターミナル"  = {key = "w", process = "terminal", command = "terminal"}
-# ↓ `d` キーはお好みのアプリを設定してください
+"ドキュメント" = {key = "d", process = "OneNote",  command = "onenote"}
+# ↓ `d` キーはお好みのアプリに変更できます
 # "ドキュメント" = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
 # "ドキュメント" = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
 # "ドキュメント" = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）

--- a/config/default.toml
+++ b/config/default.toml
@@ -38,11 +38,11 @@ Home      = {key = "5", path = "~"}
 "エディタ"    = {key = "a", process = "Code",     command = "code"}
 "ブラウザ"    = {key = "f", process = "firefox",  command = "firefox"}
 "ターミナル"  = {key = "w", process = "terminal", command = "terminal"}
-"ドキュメント" = {key = "d", process = "OneNote",  command = "onenote"}
+Document = {key = "d", process = "OneNote",  command = "onenote"}
 # ↓ `d` キーはお好みのアプリに変更できます
-# "ドキュメント" = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
-# "ドキュメント" = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
-# "ドキュメント" = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）
+# Document = {key = "d", process = "obsidian", command = "obsidian"}   # ノート（Obsidian）
+# Document = {key = "d", process = "Notion",   command = "notion"}     # ノート（Notion）
+# Document = {key = "d", process = "WINWORD",  command = "winword"}    # 文書（Word）
 # Discord       = {key = "d", process = "Discord",  command = "discord"}    # チャット（Discord）
 
 # ── タイムスタンプ ──

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,8 +47,8 @@
 - `toml` + `serde` で設定ファイルを構造体にデシリアライズ
 - `toml_edit` を使用し、コメントを保持したまま保存
 - 検索URL、アプリ名、フォルダパス、タイムスタンプ形式を設定可能
-- 各エントリにディスパッチキー (`key`) を設定可能。保存時はキー順でソート（キーなしは末尾）
-- バリデーション: タイムスタンプ形式・位置、検索URL の `{query}` プレースホルダ、ディスパッチキーの重複チェック（セクション横断）
+- 各エントリに割当キー (`key`) を設定可能。保存時はキー順でソート（キーなしは末尾）
+- バリデーション: タイムスタンプ形式・位置、検索URL の `{query}` プレースホルダ、割当キーの重複チェック（セクション横断）
 
 ---
 
@@ -108,7 +108,7 @@ graph TB
 |---------|------|------|
 | `muhenkan-switch` | bin (Tauri) | **ユーザーが直接起動する唯一のアプリ**。config.toml の閲覧・編集 UI を提供し、kanata を子プロセスとして起動・停止・再起動する。システムトレイに常駐 |
 | `muhenkan-switch-core` | bin | kanata から `cmd` アクションで呼び出される**実行エンジン**。search, switch-app, open-folder, timestamp, screenshot, dispatch サブコマンドを提供。ユーザーが直接起動することはない |
-| `muhenkan-switch-config` | lib | 設定の型定義 (`Config`, `AppEntry` 等)、config.toml の読み書き (`load`/`save`)、バリデーション、ディスパッチキー解決。GUI と CLI の**両方から依存される共有ライブラリ** |
+| `muhenkan-switch-config` | lib | 設定の型定義 (`Config`, `AppEntry` 等)、config.toml の読み書き (`load`/`save`)、バリデーション、割当キー解決。GUI と CLI の**両方から依存される共有ライブラリ** |
 
 **3 つのクレートが独立している理由:**
 
@@ -123,7 +123,7 @@ graph TB
 muhenkan-switch-core <COMMAND> [OPTIONS]
 
 Commands:
-  dispatch     <KEY>              ディスパッチキーに対応するアクションを実行
+  dispatch     <KEY>              割当キーに対応するアクションを実行
   search       --engine <NAME>    選択テキスト（クリップボード）をWeb検索
   switch-app   --target <NAME>    指定アプリを最前面に
   open-folder  --target <NAME>    指定フォルダを開く
@@ -240,7 +240,7 @@ muhenkan-switch は**無変換キーを左手親指で押しながら**他のキ
 
 ### キーボード配置の詳細
 
-#### 左手: ディスパッチキー + 固定アクション
+#### 左手: 割当キー + 固定アクション
 
 ```
   [1][2][3][4][5]         ← フォルダ (dispatch)

--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -101,7 +101,7 @@ fn default_punctuation_style() -> String {
 }
 
 impl Config {
-    /// ディスパッチキーに対応するアクションを検索する。
+    /// 割当キーに対応するアクションを検索する。
     pub fn dispatch_lookup(&self, key: &str) -> Option<DispatchAction> {
         for (name, entry) in &self.search {
             if entry.dispatch_key() == Some(key) {
@@ -263,7 +263,7 @@ fn default_search_engines() -> IndexMap<String, SearchEntry> {
 
 /// config.toml にコメントを保持しつつ保存する。
 /// 既存ファイルがあればコメントを保持、なければ新規作成。
-/// エントリはディスパッチキー順でソートされる（キーなしは末尾、名前順）。
+/// エントリは割当キー順でソートされる（キーなしは末尾、名前順）。
 pub fn save(path: &std::path::Path, config: &Config) -> Result<()> {
     use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
 
@@ -419,7 +419,7 @@ pub fn validate(config: &Config) -> Vec<String> {
         }
     }
 
-    // ディスパッチキーの重複チェック
+    // 割当キーの重複チェック
     let mut used_keys: IndexMap<String, String> = IndexMap::new();
     for (name, entry) in &config.search {
         if let Some(k) = entry.dispatch_key() {
@@ -868,7 +868,7 @@ mod tests {
 
     #[test]
     fn test_save_sorts_by_dispatch_key() {
-        // 名前のアルファベット順とディスパッチキー順が異なるデータ
+        // 名前のアルファベット順と割当キー順が異なるデータ
         let toml_str = r#"
             [search]
             gamma = {key = "g", url = "https://gamma.com/?q={query}"}

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -254,17 +254,32 @@ pub fn generate(config: &Config) -> String {
 
         // 下段ラベル（機能名/エントリ名）
         if !bottom_label.is_empty() {
-            let bot_y = key.y + 38.0;
-            let escaped = xml_escape(&bottom_label);
-            // 長いラベルはフォントサイズを縮小
-            let fs = if bottom_label.len() > 6 {
-                FONT_SIZE_BOTTOM - 2.0
+            // " (" を含む長いラベルは2行に分割
+            if let Some(pos) = bottom_label.find(" (") {
+                let line1 = xml_escape(&bottom_label[..pos]);
+                let line2 = xml_escape(&bottom_label[pos + 1..]);
+                let y1 = key.y + 33.0;
+                let y2 = key.y + 44.0;
+                let fs = FONT_SIZE_BOTTOM - 2.0;
+                svg.push_str(&format!(
+                    r##"<text x="{cx}" y="{y1}" text-anchor="middle" font-size="{fs}" fill="#666">{line1}</text>"##,
+                ));
+                svg.push_str(&format!(
+                    r##"<text x="{cx}" y="{y2}" text-anchor="middle" font-size="{fs}" fill="#666">{line2}</text>"##,
+                ));
             } else {
-                FONT_SIZE_BOTTOM
-            };
-            svg.push_str(&format!(
-                r##"<text x="{cx}" y="{bot_y}" text-anchor="middle" font-size="{fs}" fill="#666">{escaped}</text>"##,
-            ));
+                let bot_y = key.y + 38.0;
+                let escaped = xml_escape(&bottom_label);
+                let char_count = bottom_label.chars().count();
+                let fs = if char_count > 6 {
+                    FONT_SIZE_BOTTOM - 2.0
+                } else {
+                    FONT_SIZE_BOTTOM
+                };
+                svg.push_str(&format!(
+                    r##"<text x="{cx}" y="{bot_y}" text-anchor="middle" font-size="{fs}" fill="#666">{escaped}</text>"##,
+                ));
+            }
         }
     }
 
@@ -290,7 +305,7 @@ mod tests {
         let config = default_config();
         let svg = generate(&config);
         assert!(svg.contains("Google"), "SVG should contain 'Google'");
-        assert!(svg.contains("英和和英辞典"), "SVG should contain '英和和英辞典'");
+        assert!(svg.contains("英語辞典"), "SVG should contain '英語辞典'");
     }
 
     #[test]

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -16,7 +16,7 @@ struct KeyDef {
 
 #[derive(Clone, Copy, PartialEq)]
 enum KeyCategory {
-    /// 左手ディスパッチキー（config で色が決まる）
+    /// 左手割当キー（config で色が決まる）
     Dispatch,
     /// タイムスタンプキー（V, C, X）
     Timestamp,
@@ -149,7 +149,7 @@ fn key_definitions() -> Vec<KeyDef> {
     ]
 }
 
-/// config のディスパッチキーに対する割当カテゴリとエントリ名を返す。
+/// config の割当キーに対する割当カテゴリとエントリ名を返す。
 fn lookup_dispatch<'a>(config: &'a Config, key: &str) -> Option<(&'static str, &'a str)> {
     for (name, entry) in &config.folders {
         if entry.dispatch_key() == Some(key) {

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -290,7 +290,7 @@ mod tests {
         let config = default_config();
         let svg = generate(&config);
         assert!(svg.contains("Google"), "SVG should contain 'Google'");
-        assert!(svg.contains("英和辞典"), "SVG should contain '英和辞典'");
+        assert!(svg.contains("英和和英辞典"), "SVG should contain '英和和英辞典'");
     }
 
     #[test]

--- a/muhenkan-switch-core/src/main.rs
+++ b/muhenkan-switch-core/src/main.rs
@@ -43,9 +43,9 @@ enum Commands {
         #[arg(long)]
         action: String,
     },
-    /// ディスパッチキーに対応するアクションを実行
+    /// 割当キーに対応するアクションを実行
     Dispatch {
-        /// ディスパッチキー (config.toml の key フィールドに対応)
+        /// 割当キー (config.toml の key フィールドに対応)
         key: String,
     },
     /// GUI 設定ウィンドウを前面に出す（未起動なら起動する）

--- a/muhenkan-switch/frontend/index.html
+++ b/muhenkan-switch/frontend/index.html
@@ -130,7 +130,7 @@
       <!-- Apps -->
       <div class="panel" id="panel-apps">
         <h2>アプリ切り替え</h2>
-        <p class="hint">プロセス名。選択ボタンで実行中のプロセスから選べます。</p>
+        <p class="hint">リストにないアプリや機能の追加は「選択」ボタンで実行中のプロセスから登録できます。</p>
         <div class="dynamic-list" id="apps-list"></div>
         <button class="btn-add" id="btn-add-app">+ 追加</button>
       </div>

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -14,6 +14,144 @@ const DISPATCH_KEYS = [
   "z", "b",
 ];
 
+// ── App presets (OS-aware) ──
+function detectOS() {
+  const ua = navigator.userAgent;
+  if (ua.includes("Win")) return "windows";
+  if (ua.includes("Mac")) return "macos";
+  return "linux";
+}
+
+const APP_PRESETS = (() => {
+  const os = detectOS();
+  if (os === "windows") {
+    return {
+      "エディタ": [
+        { label: "VS Code", process: "Code", command: "code" },
+        { label: "Cursor", process: "Cursor", command: "cursor" },
+        { label: "Zed", process: "Zed", command: "zed" },
+      ],
+      "ブラウザ": [
+        { label: "Edge", process: "msedge", command: "msedge" },
+        { label: "Chrome", process: "chrome", command: "chrome" },
+        { label: "Firefox", process: "firefox", command: "firefox" },
+        { label: "Zen", process: "zen", command: "zen" },
+      ],
+      "ドキュメント": [
+        { label: "OneNote", process: "OneNote", command: "onenote" },
+        { label: "Obsidian", process: "Obsidian", command: "obsidian" },
+        { label: "Notion", process: "Notion", command: "notion" },
+        { label: "Word", process: "WINWORD", command: "winword" },
+      ],
+      "チャット": [
+        { label: "Slack", process: "slack", command: "slack" },
+        { label: "Discord", process: "Discord", command: "discord" },
+        { label: "Teams", process: "ms-teams", command: "ms-teams" },
+      ],
+      "ターミナル": [
+        { label: "Windows Terminal", process: "WindowsTerminal", command: "wt" },
+        { label: "Alacritty", process: "alacritty", command: "alacritty" },
+      ],
+    };
+  } else if (os === "macos") {
+    return {
+      "エディタ": [
+        { label: "VS Code", process: "Visual Studio Code", command: "code" },
+        { label: "Cursor", process: "Cursor", command: "open -a Cursor" },
+        { label: "Zed", process: "Zed", command: "open -a Zed" },
+      ],
+      "ブラウザ": [
+        { label: "Safari", process: "Safari", command: "open -a Safari" },
+        { label: "Chrome", process: "Google Chrome", command: "open -a 'Google Chrome'" },
+        { label: "Firefox", process: "firefox", command: "open -a Firefox" },
+        { label: "Zen", process: "zen", command: "open -a 'Zen Browser'" },
+      ],
+      "ドキュメント": [
+        { label: "OneNote", process: "Microsoft OneNote", command: "open -a 'Microsoft OneNote'" },
+        { label: "Obsidian", process: "Obsidian", command: "open -a Obsidian" },
+        { label: "Notion", process: "Notion", command: "open -a Notion" },
+        { label: "Word", process: "Microsoft Word", command: "open -a 'Microsoft Word'" },
+      ],
+      "チャット": [
+        { label: "Slack", process: "Slack", command: "open -a Slack" },
+        { label: "Discord", process: "Discord", command: "open -a Discord" },
+        { label: "Teams", process: "Microsoft Teams", command: "open -a 'Microsoft Teams'" },
+      ],
+      "ターミナル": [
+        { label: "Terminal", process: "Terminal", command: "open -a Terminal" },
+        { label: "iTerm2", process: "iTerm2", command: "open -a iTerm" },
+        { label: "Alacritty", process: "alacritty", command: "open -a Alacritty" },
+      ],
+    };
+  } else {
+    return {
+      "エディタ": [
+        { label: "VS Code", process: "code", command: "code" },
+        { label: "Cursor", process: "cursor", command: "cursor" },
+        { label: "Zed", process: "zed", command: "zed" },
+      ],
+      "ブラウザ": [
+        { label: "Firefox", process: "firefox", command: "firefox" },
+        { label: "Chrome", process: "google-chrome", command: "google-chrome" },
+        { label: "Zen", process: "zen", command: "zen" },
+      ],
+      "ドキュメント": [
+        { label: "OneNote", process: "onenote", command: "onenote" },
+        { label: "Obsidian", process: "obsidian", command: "obsidian" },
+        { label: "Notion", process: "Notion", command: "notion-app" },
+        { label: "LibreOffice Writer", process: "soffice", command: "libreoffice --writer" },
+      ],
+      "チャット": [
+        { label: "Slack", process: "Slack", command: "slack" },
+        { label: "Discord", process: "Discord", command: "discord" },
+      ],
+      "ターミナル": [
+        { label: "GNOME Terminal", process: "gnome-terminal", command: "gnome-terminal" },
+        { label: "Alacritty", process: "alacritty", command: "alacritty" },
+        { label: "Kitty", process: "kitty", command: "kitty" },
+      ],
+    };
+  }
+})();
+
+// ── App select dropdown helper ──
+function createAppSelect(currentProcess = "", currentCommand = "") {
+  const select = document.createElement("select");
+  select.className = "app-select";
+
+  const noneOpt = document.createElement("option");
+  noneOpt.value = "";
+  noneOpt.textContent = "—";
+  select.appendChild(noneOpt);
+
+  let hasCurrentProcess = !currentProcess;
+
+  for (const [category, apps] of Object.entries(APP_PRESETS)) {
+    const group = document.createElement("optgroup");
+    group.label = category;
+    for (const app of apps) {
+      const opt = document.createElement("option");
+      opt.value = app.process;
+      opt.textContent = app.label;
+      opt.dataset.command = app.command;
+      group.appendChild(opt);
+      if (app.process === currentProcess) hasCurrentProcess = true;
+    }
+    select.appendChild(group);
+  }
+
+  if (currentProcess && !hasCurrentProcess) {
+    const opt = document.createElement("option");
+    opt.value = currentProcess;
+    opt.textContent = `${currentProcess}（カスタム）`;
+    opt.dataset.command = currentCommand || currentProcess.toLowerCase();
+    select.appendChild(opt);
+  }
+
+  select.value = currentProcess || "";
+  return select;
+}
+
 // ── Tab switching ──
 document.querySelectorAll(".tab").forEach((tab) => {
   tab.addEventListener("click", () => {
@@ -257,20 +395,33 @@ function addAppRow(container, name = "", process = "", command = "", dispatchKey
   const row = document.createElement("div");
   row.className = "list-row";
   row.innerHTML = `
-    <input type="text" class="key-input" placeholder="名前" value="${escapeHtml(name)}">
-    <input type="text" class="process-input" placeholder="プロセス名" value="${escapeHtml(process)}" readonly>
-    <input type="hidden" class="command-input" value="${escapeHtml(command)}">
-    <button class="btn-pick-process" title="プロセス選択">選択</button>
+    <input type="text" class="key-input" placeholder="機能名" value="${escapeHtml(name)}">
+    <button class="btn-pick-process" title="実行中のプロセスから選択">選択</button>
     <button class="btn-remove" title="削除">&times;</button>
   `;
   const keySelect = createDispatchKeySelect(dispatchKey);
   row.insertBefore(keySelect, row.firstChild);
+
+  const appSelect = createAppSelect(process, command);
+  const nameInput = row.querySelector(".key-input");
+  nameInput.insertAdjacentElement("afterend", appSelect);
+
   row.querySelector(".btn-remove").addEventListener("click", () => row.remove());
   row.querySelector(".btn-pick-process").addEventListener("click", async () => {
     const selected = await showProcessPicker();
     if (selected) {
-      row.querySelector(".process-input").value = selected;
-      row.querySelector(".command-input").value = selected.toLowerCase();
+      let found = false;
+      for (const opt of appSelect.options) {
+        if (opt.value === selected) { found = true; break; }
+      }
+      if (!found) {
+        const opt = document.createElement("option");
+        opt.value = selected;
+        opt.textContent = `${selected}（カスタム）`;
+        opt.dataset.command = selected.toLowerCase();
+        appSelect.appendChild(opt);
+      }
+      appSelect.value = selected;
     }
   });
   container.appendChild(row);
@@ -412,10 +563,12 @@ function collectConfig() {
   // Apps
   for (const row of document.querySelectorAll("#apps-list .list-row")) {
     const name = row.querySelector(".key-input").value.trim();
-    const process = row.querySelector(".process-input").value.trim();
-    const command = row.querySelector(".command-input").value.trim();
+    const appSelect = row.querySelector(".app-select");
+    const process = appSelect.value;
+    const selectedOpt = appSelect.options[appSelect.selectedIndex];
+    const command = selectedOpt?.dataset?.command || "";
     const dispatchKey = row.querySelector(".dispatch-key-select").value;
-    if (name) {
+    if (name && process) {
       const entry = { process };
       if (dispatchKey) entry.key = dispatchKey;
       if (command) entry.command = command;

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -14,105 +14,8 @@ const DISPATCH_KEYS = [
   "z", "b",
 ];
 
-// ── App presets (OS-aware) ──
-function detectOS() {
-  const ua = navigator.userAgent;
-  if (ua.includes("Win")) return "windows";
-  if (ua.includes("Mac")) return "macos";
-  return "linux";
-}
-
-const APP_PRESETS = (() => {
-  const os = detectOS();
-  if (os === "windows") {
-    return {
-      "エディタ": [
-        { label: "VS Code", process: "Code", command: "code" },
-        { label: "Cursor", process: "Cursor", command: "cursor" },
-        { label: "Zed", process: "Zed", command: "zed" },
-      ],
-      "ブラウザ": [
-        { label: "Edge", process: "msedge", command: "msedge" },
-        { label: "Chrome", process: "chrome", command: "chrome" },
-        { label: "Firefox", process: "firefox", command: "firefox" },
-        { label: "Zen", process: "zen", command: "zen" },
-      ],
-      "ドキュメント": [
-        { label: "OneNote", process: "OneNote", command: "onenote" },
-        { label: "Obsidian", process: "Obsidian", command: "obsidian" },
-        { label: "Notion", process: "Notion", command: "notion" },
-        { label: "Word", process: "WINWORD", command: "winword" },
-      ],
-      "チャット": [
-        { label: "Slack", process: "slack", command: "slack" },
-        { label: "Discord", process: "Discord", command: "discord" },
-        { label: "Teams", process: "ms-teams", command: "ms-teams" },
-      ],
-      "ターミナル": [
-        { label: "Windows Terminal", process: "WindowsTerminal", command: "wt" },
-        { label: "Alacritty", process: "alacritty", command: "alacritty" },
-      ],
-    };
-  } else if (os === "macos") {
-    return {
-      "エディタ": [
-        { label: "VS Code", process: "Visual Studio Code", command: "code" },
-        { label: "Cursor", process: "Cursor", command: "open -a Cursor" },
-        { label: "Zed", process: "Zed", command: "open -a Zed" },
-      ],
-      "ブラウザ": [
-        { label: "Safari", process: "Safari", command: "open -a Safari" },
-        { label: "Chrome", process: "Google Chrome", command: "open -a 'Google Chrome'" },
-        { label: "Firefox", process: "firefox", command: "open -a Firefox" },
-        { label: "Zen", process: "zen", command: "open -a 'Zen Browser'" },
-      ],
-      "ドキュメント": [
-        { label: "OneNote", process: "Microsoft OneNote", command: "open -a 'Microsoft OneNote'" },
-        { label: "Obsidian", process: "Obsidian", command: "open -a Obsidian" },
-        { label: "Notion", process: "Notion", command: "open -a Notion" },
-        { label: "Word", process: "Microsoft Word", command: "open -a 'Microsoft Word'" },
-      ],
-      "チャット": [
-        { label: "Slack", process: "Slack", command: "open -a Slack" },
-        { label: "Discord", process: "Discord", command: "open -a Discord" },
-        { label: "Teams", process: "Microsoft Teams", command: "open -a 'Microsoft Teams'" },
-      ],
-      "ターミナル": [
-        { label: "Terminal", process: "Terminal", command: "open -a Terminal" },
-        { label: "iTerm2", process: "iTerm2", command: "open -a iTerm" },
-        { label: "Alacritty", process: "alacritty", command: "open -a Alacritty" },
-      ],
-    };
-  } else {
-    return {
-      "エディタ": [
-        { label: "VS Code", process: "code", command: "code" },
-        { label: "Cursor", process: "cursor", command: "cursor" },
-        { label: "Zed", process: "zed", command: "zed" },
-      ],
-      "ブラウザ": [
-        { label: "Firefox", process: "firefox", command: "firefox" },
-        { label: "Chrome", process: "google-chrome", command: "google-chrome" },
-        { label: "Zen", process: "zen", command: "zen" },
-      ],
-      "ドキュメント": [
-        { label: "OneNote", process: "onenote", command: "onenote" },
-        { label: "Obsidian", process: "obsidian", command: "obsidian" },
-        { label: "Notion", process: "Notion", command: "notion-app" },
-        { label: "LibreOffice Writer", process: "soffice", command: "libreoffice --writer" },
-      ],
-      "チャット": [
-        { label: "Slack", process: "Slack", command: "slack" },
-        { label: "Discord", process: "Discord", command: "discord" },
-      ],
-      "ターミナル": [
-        { label: "GNOME Terminal", process: "gnome-terminal", command: "gnome-terminal" },
-        { label: "Alacritty", process: "alacritty", command: "alacritty" },
-        { label: "Kitty", process: "kitty", command: "kitty" },
-      ],
-    };
-  }
-})();
+// ── App presets (loaded from backend) ──
+let APP_PRESETS = {};
 
 // ── App select dropdown helper ──
 function createAppSelect(currentProcess = "", currentCommand = "") {
@@ -165,7 +68,10 @@ document.querySelectorAll(".tab").forEach((tab) => {
 // ── Load config on startup ──
 async function loadConfig() {
   try {
-    config = await invoke("get_config");
+    [config, APP_PRESETS] = await Promise.all([
+      invoke("get_config"),
+      invoke("get_app_presets"),
+    ]);
     renderConfig();
   } catch (e) {
     console.error("設定の読み込みに失敗:", e);

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -364,7 +364,7 @@ function validateDispatchKeys() {
     const key = select.value;
     if (!key) continue;
     if (usedKeys[key]) {
-      return `ディスパッチキー "${key.toUpperCase()}" が重複しています`;
+      return `割当キー "${key.toUpperCase()}" が重複しています`;
     }
     usedKeys[key] = true;
   }

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -312,6 +312,13 @@ function addAppRow(container, name = "", process = "", command = "", dispatchKey
   const nameInput = row.querySelector(".key-input");
   nameInput.insertAdjacentElement("afterend", appSelect);
 
+  appSelect.addEventListener("change", () => {
+    const selected = appSelect.options[appSelect.selectedIndex];
+    if (selected && selected.parentElement.tagName === "OPTGROUP") {
+      nameInput.value = selected.parentElement.label;
+    }
+  });
+
   row.querySelector(".btn-remove").addEventListener("click", () => row.remove());
   row.querySelector(".btn-pick-process").addEventListener("click", async () => {
     const selected = await showProcessPicker();

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -315,7 +315,8 @@ function addAppRow(container, name = "", process = "", command = "", dispatchKey
   appSelect.addEventListener("change", () => {
     const selected = appSelect.options[appSelect.selectedIndex];
     if (selected && selected.parentElement.tagName === "OPTGROUP") {
-      nameInput.value = selected.parentElement.label;
+      const category = selected.parentElement.label;
+      nameInput.value = `${category} (${selected.textContent})`;
     }
   });
 
@@ -473,15 +474,19 @@ function collectConfig() {
     }
   }
 
-  // Apps
+  // Apps — 機能名の重複を防ぐ（IndexMap のキー重複で上書きされるのを回避）
   for (const row of document.querySelectorAll("#apps-list .list-row")) {
-    const name = row.querySelector(".key-input").value.trim();
+    let name = row.querySelector(".key-input").value.trim();
     const appSelect = row.querySelector(".app-select");
     const process = appSelect.value;
     const selectedOpt = appSelect.options[appSelect.selectedIndex];
     const command = selectedOpt?.dataset?.command || "";
     const dispatchKey = row.querySelector(".dispatch-key-select").value;
     if (name && process) {
+      if (collected.apps[name]) {
+        const appLabel = selectedOpt?.textContent || process;
+        name = `${name} (${appLabel})`;
+      }
       const entry = { process };
       if (dispatchKey) entry.key = dispatchKey;
       if (command) entry.command = command;

--- a/muhenkan-switch/frontend/styles/main.css
+++ b/muhenkan-switch/frontend/styles/main.css
@@ -281,6 +281,10 @@ button:disabled {
   font-size: 11px;
 }
 
+.list-row .app-select {
+  flex: 1;
+}
+
 .list-row .dispatch-key-select {
   width: 52px;
   flex: none;

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -110,6 +110,22 @@ pub async fn import_config(app: tauri::AppHandle) -> Result<Option<Config>, Stri
     }
 }
 
+// ── App presets ──
+
+/// コンパイル時に埋め込んだ app-presets.json から現在の OS 用プリセットを返す。
+#[tauri::command]
+pub fn get_app_presets() -> Result<serde_json::Value, String> {
+    const PRESETS_JSON: &str = include_str!("../../config/app-presets.json");
+    let all: serde_json::Value =
+        serde_json::from_str(PRESETS_JSON).map_err(|e| e.to_string())?;
+    let os_key = match std::env::consts::OS {
+        "windows" => "windows",
+        "macos" => "macos",
+        _ => "linux",
+    };
+    Ok(all.get(os_key).cloned().unwrap_or(serde_json::Value::Object(Default::default())))
+}
+
 // ── Kanata commands ──
 
 #[derive(Serialize, Clone)]

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
             commands::get_kanata_status,
             commands::start_kanata,
             commands::stop_kanata,
+            commands::get_app_presets,
             commands::get_running_processes,
             commands::get_autostart_enabled,
             commands::set_autostart_enabled,


### PR DESCRIPTION
## Summary
- 「ディスパッチキー」→「割当キー」に用語統一（config / docs / Rust / JS）
- 検索エンジン名を OS 別ファイルに同期（英語辞典 / Question）
- アプリ選択を readonly テキストボックスから **プルダウンリスト** に変更
  - OS 別プリセット（エディタ / ブラウザ / Document / チャット / ターミナル）を `<optgroup>` で提供
  - プリセットデータは `config/app-presets.json` に外出し、Rust 経由で配信
  - プルダウン変更時にカテゴリ名 + アプリ名を機能名に自動反映
  - リストにないアプリは「選択」ボタンでカスタム登録可能
- D キーに OneNote をデフォルト設定（未インストール時の例外処理あり）
- デフォルト設定を「機能名 (アプリ名)」形式に統一し、ニーモニックを明示
  - F = **F**irefox, S = **S**lack, D = **D**ocument, W = **W**inTerm
- SVG キーボード表示の改善
  - 長いラベル（` (` を含む）を自動2行表示
  - 文字数判定を bytes → chars に修正
  - 「ドキュメント」→「Document」、「英和和英辞典」→「英語辞典」に短縮
- 同名機能の重複で SVG キーが未設定になるバグを修正

## Test plan
- [x] GUI のアプリタブでプルダウンからアプリを選択し、機能名が自動入力されることを確認
- [x] 同じカテゴリのアプリを複数キーに設定しても SVG が正しく表示されることを確認
- [x] 「選択」ボタンで実行中プロセスからカスタム登録できることを確認
- [x] キーボード配列ウィンドウで長いラベルが2行表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)