### PR TITLE
リセット・初期値ボタンに確認ダイアログを追加

### DIFF
--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -524,10 +524,14 @@ document.getElementById("btn-apply").addEventListener("click", async () => {
 });
 
 document.getElementById("btn-reset").addEventListener("click", async () => {
+  const yes = await ask("未保存の変更を破棄して、最後に保存した設定に戻しますか？", { title: "リセット", kind: "warning" });
+  if (!yes) return;
   await loadConfig();
 });
 
 document.getElementById("btn-defaults").addEventListener("click", async () => {
+  const yes = await ask("現在の設定を破棄して、初期値に戻しますか？", { title: "初期値に戻す", kind: "warning" });
+  if (!yes) return;
   try {
     config = await invoke("default_config");
     renderConfig();


### PR DESCRIPTION
## Summary
- リセットボタンと初期値ボタンに Tauri の `ask()` による確認ダイアログを追加
- 誤クリックによる意図しない設定変更を防止

Closes #89

## Test plan
- [ ] リセットボタンをクリック → 確認ダイアログが表示される
- [ ] ダイアログで「いいえ」→ 設定が変更されない
- [ ] ダイアログで「はい」→ 最後に保存した設定に戻る
- [ ] 初期値ボタンも同様に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)