### PR TITLE
fix: SVG 句読点表示を4パターン対応 & 全角表記を明示

### DIFF
--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -44,9 +44,15 @@ fn text_edit_label(key: &str, punctuation_style: &str) -> &'static str {
         "N" => "BS",
         "M" => "Del",
         ";" => "Esc",
-        // ,.: 句読点
-        "," => if punctuation_style == "，．" { "，" } else { "、" },
-        "." => if punctuation_style == "，．" { "．" } else { "。" },
+        // ,.: 句読点（4パターン対応）
+        "," => match punctuation_style {
+            "，．" | "，。" => "全角，",
+            _ => "、",
+        },
+        "." => match punctuation_style {
+            "，．" | "、．" => "全角．",
+            _ => "。",
+        },
         _ => "",
     }
 }


### PR DESCRIPTION
## Summary
- SVG キーボードの句読点表示で「，。」「、．」パターンの条件分岐が漏れていたのを修正
- 全角コンマ/ピリオドを「全角，」「全角．」と表記し、半角との区別を明確化
- 読点「、」句点「。」はそのまま表示（見た目で判別可能）

## Test plan
- [x] 句読点スタイルを4パターンそれぞれに変更し、SVG の `,` `.` キーの表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)