### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch-rs"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend"


### PR DESCRIPTION
## Summary
- バージョンを 0.8.1 → 0.9.0 に更新 (Cargo.toml, tauri.conf.json)

## v0.8.1 からの主な変更点
- 検索タブのプルダウンリスト化 & Google 翻訳に差し替え (#93)
- 句読点スタイルを IME 標準の4パターンに拡張 & SVG 対応 (#87, #91)
- キーボードショートカット Ctrl+S/Q, F1, Escape (#86)
- キーボード配列図 SVG の自動生成 & ヘルプ画面表示 (#78)
- リセット・初期値ボタンに確認ダイアログ追加 (#90)
- エラー時のトースト通知 & UI簡素化 (#85)
- config UI 改善（用語統一・アプリプルダウン化・SVG 表示改善）(#88)
- デフォルトキー配置の見直し & エントリ名の日本語化 (#84)
- Z キーをディスパッチキーに追加 (#82)

## マージ後
`git tag v0.9.0 && git push origin v0.9.0` でリリースワークフローが起動します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)