### PR TITLE
chore: GitHub Actions を最新メジャーバージョンに更新

### DIFF
--- a/.github/workflows/check-kanata-update.yml
+++ b/.github/workflows/check-kanata-update.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get current kanata version
         id: current

--- a/.github/workflows/check-rust-update.yml
+++ b/.github/workflows/check-rust-update.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get current Rust version from mise.toml
         id: current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -105,7 +105,7 @@ jobs:
           tar czf "muhenkan-switch-rs-${{ matrix.asset_suffix }}.tar.gz" \
             "muhenkan-switch-rs-${{ matrix.asset_suffix }}/"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.asset_suffix }}
           path: muhenkan-switch-rs-${{ matrix.asset_suffix }}.*
@@ -114,7 +114,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -158,7 +158,7 @@ jobs:
       # 5. 生成されたインストーラーを artifacts にアップロード
       #    Cargo ワークスペースの target/ はルートに置かれるため muhenkan-switch/ プレフィックスは不要
       - name: Upload NSIS artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-windows-nsis
           path: |
@@ -170,7 +170,7 @@ jobs:
     needs: [build, build-windows-nsis]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- Node.js 20 非推奨警告 (2026-06-02 期限) を解消
- `softprops/action-gh-release` は v2 が最新のため変更なし
- 使用パラメータ (`name`, `path`, `merge-multiple`) はすべて互換性あり

## Test plan
- [ ] release ワークフローが次回タグ push で正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)