### PR TITLE
feat: Linux アプリランチャー（Dock）への登録対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
               cp scripts/install/install.sh "$RELEASE_DIR/"
               cp scripts/install/uninstall.sh "$RELEASE_DIR/"
               cp scripts/install/update.sh "$RELEASE_DIR/"
+              cp muhenkan-switch/icons/128x128.png "$RELEASE_DIR/icon-128x128.png"
               chmod +x "$RELEASE_DIR/install.sh" "$RELEASE_DIR/uninstall.sh" "$RELEASE_DIR/update.sh"
               ;;
             macos-x64|macos-arm64)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Node.js やビルドステップは不要。
 - **PR 作成前にドキュメントの更新が必要か確認する。** 機能追加・変更時は以下を確認:
   - `README.md` — 機能一覧
   - `docs/design.md` — 設計・実装方針
+  - `docs/setup.md` — セットアップ手順・インストールパス
   - `config/default-*.toml` — 設定コメント
   - `muhenkan-switch/frontend/help.html` — ヘルプ画面
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@
 curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh | sh
 ```
 
-ターミナルから `muhenkan-switch` を実行してください。
+Linux ではアプリ一覧（Super キー）または Dock から `muhenkan-switch` を起動できます。
+macOS ではターミナルから `muhenkan-switch` を実行してください。
 
 無変換キーを押しながら H/J/K/L でカーソルが移動すれば成功です。
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -49,6 +49,8 @@ curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/mai
 - kanata のダウンロード（GitHub Releases から）
 - ファイルの配置（下記インストール先）
 - PATH の設定（`~/.local/bin` にシンボリックリンク）
+- アプリランチャー（Dock）への登録（Linux: `~/.local/share/applications/` に `.desktop` ファイルを作成）
+- アイコンのインストール（Linux: `~/.local/share/icons/hicolor/128x128/apps/`）
 - オプション: 自動起動の設定（Linux: XDG autostart、macOS: launchd）
 
 ### インストール先
@@ -63,7 +65,8 @@ curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/mai
 
 スタートメニューから `muhenkan-switch` を起動してください（Windows）。システムトレイに常駐し、kanata を自動管理します。
 
-Linux/macOS ではターミナルから `muhenkan-switch` を実行してください。
+Linux ではアプリ一覧（Super キー）から `muhenkan-switch` を起動できます。ターミナルから `muhenkan-switch` を実行しても起動できます。
+macOS ではターミナルから `muhenkan-switch` を実行してください。
 
 無変換キーを押しながら H/J/K/L でカーソルが移動すれば成功です。
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -62,6 +62,15 @@ icon_src="$SCRIPT_DIR/icon-128x128.png"
 if [ -f "$icon_src" ]; then
     mkdir -p "$ICON_DIR"
     cp "$icon_src" "$ICON_FILE"
+    # index.theme がなければシステムからコピー（キャッシュ更新に必要）
+    HICOLOR_DIR="$HOME/.local/share/icons/hicolor"
+    if [ ! -f "$HICOLOR_DIR/index.theme" ] && [ -f /usr/share/icons/hicolor/index.theme ]; then
+        cp /usr/share/icons/hicolor/index.theme "$HICOLOR_DIR/index.theme"
+    fi
+    # アイコンテーマキャッシュを更新
+    if command -v gtk-update-icon-cache &>/dev/null; then
+        gtk-update-icon-cache -f "$HICOLOR_DIR" 2>/dev/null || true
+    fi
     echo "[OK] アイコンをインストールしました"
 else
     echo "[SKIP] icon-128x128.png が見つかりません"
@@ -188,6 +197,7 @@ Categories=Utility;
 Keywords=keyboard;kanata;muhenkan;
 EOF
 
+chmod +x "$APP_DESKTOP_FILE"
 echo "[OK] アプリランチャーに登録しました"
 echo "     $APP_DESKTOP_FILE"
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -55,6 +55,18 @@ copy_file "muhenkan.kbd" "muhenkan.kbd"
 copy_file "update.sh" "update.sh"
 copy_file "uninstall.sh" "uninstall.sh"
 
+# ── アイコンをインストール ──
+ICON_DIR="$HOME/.local/share/icons/hicolor/128x128/apps"
+ICON_FILE="$ICON_DIR/muhenkan-switch.png"
+icon_src="$SCRIPT_DIR/icon-128x128.png"
+if [ -f "$icon_src" ]; then
+    mkdir -p "$ICON_DIR"
+    cp "$icon_src" "$ICON_FILE"
+    echo "[OK] アイコンをインストールしました"
+else
+    echo "[SKIP] icon-128x128.png が見つかりません"
+fi
+
 # 実行権限を付与
 chmod +x "$INSTALL_DIR/muhenkan-switch" 2>/dev/null || true
 chmod +x "$INSTALL_DIR/muhenkan-switch-core" 2>/dev/null || true
@@ -156,6 +168,28 @@ EOF
     echo "[OK] 自動起動を設定しました"
     echo "     $autostart_dir/muhenkan-switch.desktop"
 fi
+
+# ── アプリランチャー登録 ──
+APP_DESKTOP_DIR="$HOME/.local/share/applications"
+APP_DESKTOP_FILE="$APP_DESKTOP_DIR/muhenkan-switch.desktop"
+mkdir -p "$APP_DESKTOP_DIR"
+
+# Icon= はアイコンがインストールされていればテーマから解決される
+cat > "$APP_DESKTOP_FILE" << EOF
+[Desktop Entry]
+Type=Application
+Name=muhenkan-switch
+GenericName=キーボードカスタマイズ
+Comment=無変換キーを活用するキーボードカスタマイズツール (kanata を自動管理)
+Exec=$INSTALL_DIR/muhenkan-switch
+Icon=muhenkan-switch
+Terminal=false
+Categories=Utility;
+Keywords=keyboard;kanata;muhenkan;
+EOF
+
+echo "[OK] アプリランチャーに登録しました"
+echo "     $APP_DESKTOP_FILE"
 
 # ── uinput グループ設定の案内 ──
 echo ""

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -7,6 +7,8 @@ INSTALL_DIR="$HOME/.local/share/muhenkan-switch-rs"
 BIN_DIR="$HOME/.local/bin"
 SERVICE_FILE="$HOME/.config/systemd/user/kanata.service"
 AUTOSTART_FILE="$HOME/.config/autostart/muhenkan-switch.desktop"
+APP_DESKTOP_FILE="$HOME/.local/share/applications/muhenkan-switch.desktop"
+ICON_FILE="$HOME/.local/share/icons/hicolor/128x128/apps/muhenkan-switch.png"
 
 echo ""
 echo "=== muhenkan-switch-rs アンインストーラー (Linux) ==="
@@ -26,6 +28,12 @@ if [ -f "$SERVICE_FILE" ]; then
 fi
 if [ -f "$AUTOSTART_FILE" ]; then
     echo "  - 自動起動: $AUTOSTART_FILE"
+fi
+if [ -f "$APP_DESKTOP_FILE" ]; then
+    echo "  - アプリランチャー: $APP_DESKTOP_FILE"
+fi
+if [ -f "$ICON_FILE" ]; then
+    echo "  - アイコン: $ICON_FILE"
 fi
 echo ""
 
@@ -54,6 +62,22 @@ if [ -f "$AUTOSTART_FILE" ]; then
     echo "[OK] 自動起動設定を削除しました"
 else
     echo "[SKIP] 自動起動設定は存在しません"
+fi
+
+# ── アプリランチャー .desktop ファイル削除 ──
+if [ -f "$APP_DESKTOP_FILE" ]; then
+    rm -f "$APP_DESKTOP_FILE"
+    echo "[OK] アプリランチャー登録を削除しました"
+else
+    echo "[SKIP] アプリランチャー登録は存在しません"
+fi
+
+# ── アイコン削除 ──
+if [ -f "$ICON_FILE" ]; then
+    rm -f "$ICON_FILE"
+    echo "[OK] アイコンを削除しました"
+else
+    echo "[SKIP] アイコンは存在しません"
 fi
 
 # ── シンボリックリンク削除（安全チェック付き）──


### PR DESCRIPTION
## Summary
- `install.sh` で `~/.local/share/applications/muhenkan-switch.desktop` を生成し、アプリ一覧・Dock から起動可能にする
- アイコン (`128x128.png`) を `~/.local/share/icons/hicolor/128x128/apps/` にインストール
- `uninstall.sh` でアプリランチャー登録とアイコンを削除
- リリースワークフローで Linux アーカイブにアイコンを同梱

Closes #34

## Test plan
- [ ] `install.sh` 実行後、`~/.local/share/applications/muhenkan-switch.desktop` が作成されること
- [ ] `~/.local/share/icons/hicolor/128x128/apps/muhenkan-switch.png` がインストールされること
- [ ] Ubuntu のアプリケーション一覧（Super キー）に muhenkan-switch が表示されること
- [ ] Dock にピン留めできること
- [ ] `uninstall.sh` 実行後、`.desktop` ファイルとアイコンが削除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)