### PR TITLE
feat: Linux 外部ツール未インストール時のエラーメッセージを改善

### DIFF
--- a/muhenkan-switch-core/src/commands/keys.rs
+++ b/muhenkan-switch-core/src/commands/keys.rs
@@ -105,20 +105,24 @@ mod imp {
 #[cfg(target_os = "linux")]
 mod imp {
     use super::*;
+    use anyhow::Context;
     use std::process::Command;
 
-    pub(super) fn simulate_copy() -> Result<()> {
+    /// xdotool の存在を確認し、なければインストール案内付きエラーを返す
+    fn run_xdotool(args: &[&str]) -> Result<()> {
         Command::new("xdotool")
-            .args(["key", "ctrl+c"])
-            .output()?;
+            .args(args)
+            .output()
+            .context("xdotool が見つかりません。以下のコマンドでインストールしてください:\n  sudo apt install xdotool")?;
         Ok(())
     }
 
+    pub(super) fn simulate_copy() -> Result<()> {
+        run_xdotool(&["key", "ctrl+c"])
+    }
+
     pub(super) fn simulate_type(text: &str) -> Result<()> {
-        Command::new("xdotool")
-            .args(["type", "--clearmodifiers", text])
-            .output()?;
-        Ok(())
+        run_xdotool(&["type", "--clearmodifiers", text])
     }
 }
 

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -24,6 +24,16 @@ fn notify_process_not_found(app: &str) {
     toast.finish(&msg);
 }
 
+/// wmctrl / xdotool の両方が未インストールの場合に警告を出す。
+#[cfg(target_os = "linux")]
+fn warn_no_window_tools() {
+    eprintln!(
+        "Warning: wmctrl / xdotool がインストールされていません。\n\
+         アプリ切り替え機能を使うには以下のコマンドでインストールしてください:\n  \
+         sudo apt install wmctrl xdotool"
+    );
+}
+
 // ── Platform: Windows ──
 
 #[cfg(target_os = "windows")]
@@ -270,6 +280,9 @@ mod imp {
             || try_xdotool(app, "--name");
 
         if !activated {
+            if !has_command("wmctrl") && !has_command("xdotool") {
+                warn_no_window_tools();
+            }
             if let Some(cmd) = launch {
                 if let Err(e) = Command::new("sh").args(["-c", cmd]).spawn() {
                     eprintln!("Warning: failed to launch '{}': {}", cmd, e);
@@ -292,6 +305,9 @@ mod imp {
             || try_xdotool(app, "--name");
 
         if !activated {
+            if !has_command("wmctrl") && !has_command("xdotool") {
+                warn_no_window_tools();
+            }
             if let Some(cmd) = launch {
                 if let Err(e) = Command::new("sh").args(["-c", cmd]).spawn() {
                     eprintln!("Warning: failed to launch '{}': {}", cmd, e);
@@ -302,6 +318,15 @@ mod imp {
         }
 
         Ok(())
+    }
+
+    /// コマンドが PATH 上に存在するか確認する
+    fn has_command(cmd: &str) -> bool {
+        Command::new("which")
+            .arg(cmd)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
     }
 
     pub(super) fn try_wmctrl(app: &str) -> bool {


### PR DESCRIPTION
## Summary
- `keys.rs`: xdotool 未インストール時に `sudo apt install xdotool` を案内するエラーメッセージに改善
- `switch_app.rs`: wmctrl / xdotool 両方未インストール時に `sudo apt install wmctrl xdotool` を案内する警告を表示
- ツールの存在チェック用 `has_command()` ヘルパーを追加

Closes #15

## Test plan
- [x] xdotool 未インストール環境で `muhenkan-switch-core keys type "test"` を実行し、インストール案内が表示されること
- [x] wmctrl/xdotool 未インストール環境で `muhenkan-switch-core switch-app` を実行し、警告が表示されること
- [x] wmctrl/xdotool インストール済み環境で通常通り動作すること
- [x] `cargo test -p muhenkan-switch-core` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)