### PR TITLE
rename: muhenkan-switch-rs → muhenkan-switch の全参照を更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Package release
         shell: bash
         run: |
-          RELEASE_DIR="muhenkan-switch-rs-${{ matrix.asset_suffix }}"
+          RELEASE_DIR="muhenkan-switch-${{ matrix.asset_suffix }}"
           mkdir -p "$RELEASE_DIR"
 
           # muhenkan-switch-core バイナリ
@@ -103,13 +103,13 @@ jobs:
       - name: Create archive (Unix)
         if: runner.os != 'Windows'
         run: |
-          tar czf "muhenkan-switch-rs-${{ matrix.asset_suffix }}.tar.gz" \
-            "muhenkan-switch-rs-${{ matrix.asset_suffix }}/"
+          tar czf "muhenkan-switch-${{ matrix.asset_suffix }}.tar.gz" \
+            "muhenkan-switch-${{ matrix.asset_suffix }}/"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.asset_suffix }}
-          path: muhenkan-switch-rs-${{ matrix.asset_suffix }}.*
+          path: muhenkan-switch-${{ matrix.asset_suffix }}.*
 
   build-windows-nsis:
     runs-on: windows-latest
@@ -183,7 +183,7 @@ jobs:
           SETUP_SIG="${SETUP_EXE}.sig"
           ARTIFACT_NAME=$(basename "$SETUP_EXE")
           SIGNATURE=$(cat "$SETUP_SIG")
-          DOWNLOAD_URL="https://github.com/kimushun1101/muhenkan-switch-rs/releases/download/v${VERSION}/${ARTIFACT_NAME}"
+          DOWNLOAD_URL="https://github.com/kimushun1101/muhenkan-switch/releases/download/v${VERSION}/${ARTIFACT_NAME}"
           cat > latest.json <<EOF
           {
             "version": "${VERSION}",
@@ -202,11 +202,11 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            muhenkan-switch-rs-*.tar.gz
+            muhenkan-switch-*.tar.gz
             *-setup.exe
             latest.json
           body: |
-            ## muhenkan-switch-rs
+            ## muhenkan-switch
 
             ### Windows インストール（推奨）
 
@@ -218,17 +218,17 @@ jobs:
 
             **Linux / macOS:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh | sh
+            curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.sh | sh
             ```
 
             **Windows（上級者向け PowerShell ワンライナー）:**
             ```powershell
-            irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.ps1 | iex
+            irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.ps1 | iex
             ```
 
             ### ダウンロード
             - **Windows (x64)**: `muhenkan-switch_x64-setup.exe`
-            - **Linux (x64)**: `muhenkan-switch-rs-linux-x64.tar.gz`
-            - **macOS (x64)**: `muhenkan-switch-rs-macos-x64.tar.gz` ⚠️ 未検証
-            - **macOS (ARM)**: `muhenkan-switch-rs-macos-arm64.tar.gz` ⚠️ 未検証
+            - **Linux (x64)**: `muhenkan-switch-linux-x64.tar.gz`
+            - **macOS (x64)**: `muhenkan-switch-macos-x64.tar.gz` ⚠️ 未検証
+            - **macOS (ARM)**: `muhenkan-switch-macos-arm64.tar.gz` ⚠️ 未検証
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 version = "0.9.0"
 edition = "2021"
 license = "LGPL-3.0-only"
-repository = "https://github.com/kimushun1101/muhenkan-switch-rs"
+repository = "https://github.com/kimushun1101/muhenkan-switch"
 
 [workspace.dependencies]
 muhenkan-switch-config = { path = "muhenkan-switch-config" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This repository (muhenkan-switch-rs) is licensed under the GNU Lesser General
+This repository (muhenkan-switch) is licensed under the GNU Lesser General
 Public License v3.0 (LGPL-3.0-only).
 
 This repository bundles kanata (https://github.com/jtroo/kanata) in binary form.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# muhenkan-switch-rs
+# muhenkan-switch
 
 無変換キーと同時押しを起点としたクロスプラットフォーム・ショートカットツール。
 
-[muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch)（AutoHotkey版）を
-[kanata](https://github.com/jtroo/kanata) + Rust製バイナリ で再実装したものです。
+[kanata](https://github.com/jtroo/kanata) + Rust製バイナリ で実装しています。
 
 ## 対応環境
 
@@ -36,19 +35,19 @@
 
 ### Windows
 
-[最新リリース](https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest) から
+[最新リリース](https://github.com/kimushun1101/muhenkan-switch/releases/latest) から
 `muhenkan-switch_x64-setup.exe` をダウンロードしてインストール。
 スタートメニューから `muhenkan-switch` を起動してください。
 
 > 上記を自動で実施するスクリプトは以下のとおりです。PowerShellにコマンドを入力してください。
 > ```powershell
-> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.ps1 | iex
+> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.ps1 | iex
 > ```
 
 ### Linux / macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh | sh
+curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.sh | sh
 ```
 
 Linux ではアプリ一覧（Super キー）または Dock から `muhenkan-switch` を起動できます。
@@ -100,12 +99,8 @@ kanata の設定ガイドは [こちら](https://github.com/jtroo/kanata/wiki/Co
 
 LGPL-3.0-only
 
-本プロジェクト（muhenkan-switch-rs）は Rust によるフルスクラッチ実装です。
-旧版（[muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch) AutoHotkey 版）の仕様を一部継承していますが、
-コードの流用はないため LGPL-3.0 で提供します。
-
 同梱する kanata も LGPL-3.0 です（`LICENSE` 参照）。
 
 ## 旧版（AutoHotkey版）
 
-Windows 専用の AutoHotkey 版は [muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch) にあります。
+Windows 専用の AutoHotkey 版は [muhenkan-switch-ahk](https://github.com/kimushun1101/muhenkan-switch-ahk) にあります。

--- a/config/default-linux.toml
+++ b/config/default-linux.toml
@@ -1,4 +1,4 @@
-# muhenkan-switch-rs 設定ファイル (Linux)
+# muhenkan-switch 設定ファイル (Linux)
 # muhenkan-switch バイナリと同じディレクトリに config.toml としてコピーして使用してください。
 
 # ── 句読点スタイル ──

--- a/config/default-macos.toml
+++ b/config/default-macos.toml
@@ -1,4 +1,4 @@
-# muhenkan-switch-rs 設定ファイル (macOS)
+# muhenkan-switch 設定ファイル (macOS)
 # muhenkan-switch バイナリと同じディレクトリに config.toml としてコピーして使用してください。
 
 # ── 句読点スタイル ──

--- a/config/default-windows.toml
+++ b/config/default-windows.toml
@@ -1,4 +1,4 @@
-# muhenkan-switch-rs 設定ファイル (Windows)
+# muhenkan-switch 設定ファイル (Windows)
 # muhenkan-switch バイナリと同じディレクトリに config.toml としてコピーして使用してください。
 
 # ── 句読点スタイル ──

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,4 +1,4 @@
-# muhenkan-switch-rs 設定ファイル（共通フォールバック）
+# muhenkan-switch 設定ファイル（共通フォールバック）
 # OS 別の設定は default-windows.toml / default-macos.toml / default-linux.toml を参照してください。
 
 # ── 句読点スタイル ──

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 ## 概要
 
-現行の `muhenkan-switch`（AutoHotkey v2、Windows専用）をマルチプラットフォーム化する。
+旧版の `muhenkan-switch-ahk`（AutoHotkey v2、Windows専用）をマルチプラットフォーム化する。
 
 **アーキテクチャ:** kanata（既存OSSキーリマッパー）＋ Rust製 muhenkan-switch バイナリ ＋ Tauri v2 GUI
 
@@ -85,7 +85,7 @@ sequenceDiagram
 
 ```mermaid
 graph TB
-    subgraph "muhenkan-switch-rs (Cargo workspace)"
+    subgraph "muhenkan-switch (Cargo workspace)"
         GUI["<b>muhenkan-switch</b><br/>bin (Tauri v2)<br/>設定画面 / kanata 管理 / トレイ常駐"]
         kanata["<b>kanata</b><br/>外部バイナリ (.kbd)<br/>Layer 1: キー入力"]
         CLI["<b>muhenkan-switch-core</b><br/>bin (CLI)<br/>Layer 2: OS 連携<br/>search / switch-app / open-folder 等"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,13 +65,13 @@ mise run test       # ユニットテスト
 
 ```powershell
 # 除外に追加
-Add-MpPreference -ExclusionPath "C:\Users\<ユーザー名>\repos\muhenkan-switch-rs"
+Add-MpPreference -ExclusionPath "C:\Users\<ユーザー名>\repos\muhenkan-switch"
 
 # 確認
 Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
 # 除外を解除（開発終了後）
-Remove-MpPreference -ExclusionPath "C:\Users\<ユーザー名>\repos\muhenkan-switch-rs"
+Remove-MpPreference -ExclusionPath "C:\Users\<ユーザー名>\repos\muhenkan-switch"
 ```
 
 ## Updater 署名鍵セットアップ
@@ -106,7 +106,7 @@ npx @tauri-apps/cli@2 signer generate -w ~/.tauri/muhenkan-switch.key
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6...(公開鍵の内容)",
       "endpoints": [
-        "https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest/download/latest.json"
+        "https://github.com/kimushun1101/muhenkan-switch/releases/latest/download/latest.json"
       ]
     }
   }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,14 +4,14 @@
 
 ### Windows
 
-1. [最新リリース](https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest) から
+1. [最新リリース](https://github.com/kimushun1101/muhenkan-switch/releases/latest) から
    `muhenkan-switch_x64-setup.exe` をダウンロード
 2. ダブルクリックしてインストール
 3. スタートメニューから `muhenkan-switch` を起動
 
 > **PowerShell ワンライナーでのインストール:**
 > ```powershell
-> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.ps1 | iex
+> irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.ps1 | iex
 > ```
 
 ### Linux / macOS
@@ -19,12 +19,12 @@
 以下のコマンドをターミナルに貼り付けて実行するだけで、最新版のダウンロードからインストールまで自動で行われます。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh | sh
+curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.sh | sh
 ```
 
 > **セキュリティについて**: スクリプトの内容を事前に確認したい場合は、先にダウンロードしてから実行できます。
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh -o get.sh
+> curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.sh -o get.sh
 > less get.sh    # 内容を確認
 > bash get.sh    # 実行
 > ```
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/mai
 <details>
 <summary>手動インストール（アーカイブをダウンロードする方法、Linux/macOS）</summary>
 
-[Releases](https://github.com/kimushun1101/muhenkan-switch-rs/releases) から
+[Releases](https://github.com/kimushun1101/muhenkan-switch/releases) から
 お使いの OS 用のアーカイブをダウンロード・展開し、インストールスクリプトを実行してください。
 
 ```bash
@@ -58,8 +58,8 @@ curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/mai
 | OS | インストール先 |
 |----|--------------|
 | Windows | `%LOCALAPPDATA%\muhenkan-switch` |
-| Linux | `~/.local/share/muhenkan-switch-rs` |
-| macOS | `~/Library/Application Support/muhenkan-switch-rs` |
+| Linux | `~/.local/share/muhenkan-switch` |
+| macOS | `~/Library/Application Support/muhenkan-switch` |
 
 ## 起動
 
@@ -145,17 +145,17 @@ macOS では [Karabiner-VirtualHIDDevice](https://github.com/pqrs-org/Karabiner-
 
 ```bash
 # Linux
-~/.local/share/muhenkan-switch-rs/uninstall.sh
+~/.local/share/muhenkan-switch/uninstall.sh
 
 # macOS
-~/Library/Application\ Support/muhenkan-switch-rs/uninstall-macos.sh
+~/Library/Application\ Support/muhenkan-switch/uninstall-macos.sh
 ```
 
 ## 更新
 
 ### Windows
 
-[最新リリース](https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest) から
+[最新リリース](https://github.com/kimushun1101/muhenkan-switch/releases/latest) から
 新しい `muhenkan-switch_x64-setup.exe` をダウンロードしてダブルクリックするだけで上書き更新されます。
 アプリ起動中に自動更新チェックも行われます。
 
@@ -163,8 +163,8 @@ macOS では [Karabiner-VirtualHIDDevice](https://github.com/pqrs-org/Karabiner-
 
 ```bash
 # Linux
-~/.local/share/muhenkan-switch-rs/update.sh
+~/.local/share/muhenkan-switch/update.sh
 
 # macOS
-~/Library/Application\ Support/muhenkan-switch-rs/update-macos.sh
+~/Library/Application\ Support/muhenkan-switch/update-macos.sh
 ```

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-`muhenkan-switch-rs` は、AutoHotkey 版 [muhenkan-switch](https://github.com/kimushun1101/muhenkan-switch) をクロスプラットフォーム対応で再実装したものです。
+`muhenkan-switch` は、AutoHotkey 版 [muhenkan-switch-ahk](https://github.com/kimushun1101/muhenkan-switch-ahk) をクロスプラットフォーム対応で再実装したものです。
 
 ## 主な変更点
 
@@ -32,7 +32,7 @@
 
 ## 移行手順
 
-1. [muhenkan-switch-rs のリリースページ](https://github.com/kimushun1101/muhenkan-switch-rs/releases) からダウンロード
+1. [muhenkan-switch のリリースページ](https://github.com/kimushun1101/muhenkan-switch/releases) からダウンロード
 2. `config.toml` を自分の環境に合わせて編集（旧版の設定を手動で転記）
 3. kanata を起動して動作確認
 4. 問題なければ旧版の AutoHotkey スクリプトを無効化

--- a/mise.toml
+++ b/mise.toml
@@ -65,12 +65,12 @@ run = "bash scripts/dev/test-install.sh"
 description = "Run uninstall.sh from the install directory"
 shell = "bash -c"
 run = """
-UNINSTALL="$HOME/.local/share/muhenkan-switch-rs/uninstall.sh"
+UNINSTALL="$HOME/.local/share/muhenkan-switch/uninstall.sh"
 if [ -f "$UNINSTALL" ]; then
   bash "$UNINSTALL"
 else
   echo "[test-uninstall] uninstall.sh not found at $UNINSTALL"
-  echo "[test-uninstall] muhenkan-switch-rs is not installed."
+  echo "[test-uninstall] muhenkan-switch is not installed."
 fi
 """
 

--- a/muhenkan-switch-core/Cargo.toml
+++ b/muhenkan-switch-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "muhenkan-switch-core"
 version.workspace = true
 edition.workspace = true
-description = "Companion tool for muhenkan-switch-rs: cross-platform shortcut actions"
+description = "Companion tool for muhenkan-switch: cross-platform shortcut actions"
 license.workspace = true
 repository.workspace = true
 

--- a/muhenkan-switch-core/src/commands/context.rs
+++ b/muhenkan-switch-core/src/commands/context.rs
@@ -121,7 +121,7 @@ mod imp {
 mod imp {
     /// macOS: Finder の前面ウィンドウ検出は未実装。
     /// osascript で System Events / Finder の frontmost 判定が可能。
-    /// See: https://github.com/kimushun1101/muhenkan-switch-rs/issues/19
+    /// See: https://github.com/kimushun1101/muhenkan-switch/issues/19
     pub(super) fn get_foreground_explorer_hwnd() -> Option<isize> {
         None
     }

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -350,7 +350,7 @@ mod imp {
 
     /// macOS: Finder の選択ファイル取得は未実装。
     /// osascript で Finder の selection を取得可能。
-    /// See: https://github.com/kimushun1101/muhenkan-switch-rs/issues/19
+    /// See: https://github.com/kimushun1101/muhenkan-switch/issues/19
     pub(super) fn get_selected_paths(_hwnd: isize) -> Result<Vec<PathBuf>> {
         anyhow::bail!("File manager selection is not yet supported on macOS")
     }

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -677,7 +677,7 @@ document.getElementById("btn-help").addEventListener("click", async () => {
 
 document.getElementById("btn-github").addEventListener("click", async () => {
   const { open } = window.__TAURI__.shell;
-  await open("https://github.com/kimushun1101/muhenkan-switch-rs");
+  await open("https://github.com/kimushun1101/muhenkan-switch");
 });
 
 document.getElementById("btn-open-dir").addEventListener("click", async () => {

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -52,7 +52,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU4QjMwNjgyMDFFMUNDREQKUldUZHpPRUJnZ2F6V0RlS0cxMlcyL3Q2d2lLa0QrNGFOM0tDM0hkUS8ycmI1UVpIOE12T0MxMjgK",
       "endpoints": [
-        "https://github.com/kimushun1101/muhenkan-switch-rs/releases/latest/download/latest.json"
+        "https://github.com/kimushun1101/muhenkan-switch/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/scripts/dev/test-install.sh
+++ b/scripts/dev/test-install.sh
@@ -7,7 +7,7 @@ if [ "$(uname)" != "Linux" ]; then
   exit 1
 fi
 
-STAGING="tmp-test-install/muhenkan-switch-rs-linux-x64"
+STAGING="tmp-test-install/muhenkan-switch-linux-x64"
 rm -rf tmp-test-install
 mkdir -p "$STAGING"
 

--- a/scripts/install/get.ps1
+++ b/scripts/install/get.ps1
@@ -1,22 +1,22 @@
 <#
 .SYNOPSIS
-    muhenkan-switch-rs ワンライナーインストーラー (Windows)
+    muhenkan-switch ワンライナーインストーラー (Windows)
 .DESCRIPTION
     GitHub Releases から最新の setup.exe をダウンロードし、実行します。
 .NOTES
     使い方:
-    irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.ps1 | iex
+    irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.ps1 | iex
 #>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 # ── 設定 ──
-$REPO = "kimushun1101/muhenkan-switch-rs"
+$REPO = "kimushun1101/muhenkan-switch"
 $ASSET_NAME = "muhenkan-switch_x64-setup.exe"
 
 Write-Host ""
-Write-Host "=== muhenkan-switch-rs インストーラー (Windows) ===" -ForegroundColor Cyan
+Write-Host "=== muhenkan-switch インストーラー (Windows) ===" -ForegroundColor Cyan
 Write-Host ""
 
 # ── TLS 1.2 を有効化 ──

--- a/scripts/install/get.sh
+++ b/scripts/install/get.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs ワンライナーインストーラー
+# muhenkan-switch ワンライナーインストーラー
 #
 # 使い方:
-#   curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.sh | sh
 #
 # パイプ実行時は一時ファイルに保存してから bash で実行するため、
 # install スクリプト内の read プロンプトも正常に動作します。
@@ -19,10 +19,10 @@ if [ ! -t 0 ]; then
 fi
 
 # ── 設定 ──
-REPO="kimushun1101/muhenkan-switch-rs"
+REPO="kimushun1101/muhenkan-switch"
 
 echo ""
-echo "=== muhenkan-switch-rs インストーラー ==="
+echo "=== muhenkan-switch インストーラー ==="
 echo ""
 
 # ── OS・アーキテクチャ検出 ──
@@ -32,7 +32,7 @@ ARCH=$(uname -m)
 case "$OS" in
     Linux)
         case "$ARCH" in
-            x86_64) ASSET_NAME="muhenkan-switch-rs-linux-x64.tar.gz" ;;
+            x86_64) ASSET_NAME="muhenkan-switch-linux-x64.tar.gz" ;;
             *) echo "[ERROR] 未対応のアーキテクチャです: $ARCH"; exit 1 ;;
         esac
         INSTALL_SCRIPT="install.sh"
@@ -40,8 +40,8 @@ case "$OS" in
         ;;
     Darwin)
         case "$ARCH" in
-            arm64)  ASSET_NAME="muhenkan-switch-rs-macos-arm64.tar.gz" ;;
-            x86_64) ASSET_NAME="muhenkan-switch-rs-macos-x64.tar.gz" ;;
+            arm64)  ASSET_NAME="muhenkan-switch-macos-arm64.tar.gz" ;;
+            x86_64) ASSET_NAME="muhenkan-switch-macos-x64.tar.gz" ;;
             *) echo "[ERROR] 未対応のアーキテクチャです: $ARCH"; exit 1 ;;
         esac
         INSTALL_SCRIPT="install-macos.sh"
@@ -50,7 +50,7 @@ case "$OS" in
     *)
         echo "[ERROR] 未対応の OS です: $OS"
         echo "        Windows の場合は PowerShell で以下を実行してください:"
-        echo "        irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch-rs/main/scripts/install/get.ps1 | iex"
+        echo "        irm https://raw.githubusercontent.com/kimushun1101/muhenkan-switch/main/scripts/install/get.ps1 | iex"
         exit 1
         ;;
 esac

--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs インストールスクリプト (macOS)
+# muhenkan-switch インストールスクリプト (macOS)
 #
 # muhenkan-switch, config.toml, muhenkan-macos.kbd をインストールし、
 # kanata を GitHub からダウンロードします。
@@ -23,11 +23,11 @@ fi
 
 # ── 設定 ──
 KANATA_VERSION="v1.11.0"
-INSTALL_DIR="$HOME/Library/Application Support/muhenkan-switch-rs"
+INSTALL_DIR="$HOME/Library/Application Support/muhenkan-switch"
 BIN_DIR="$HOME/.local/bin"
 PLIST_DIR="$HOME/Library/LaunchAgents"
-PLIST_NAME="com.muhenkan-switch-rs.kanata.plist"
-LOG_DIR="$HOME/Library/Logs/muhenkan-switch-rs"
+PLIST_NAME="com.muhenkan-switch.kanata.plist"
+LOG_DIR="$HOME/Library/Logs/muhenkan-switch"
 
 # アーキテクチャ判定
 ARCH=$(uname -m)
@@ -49,7 +49,7 @@ esac
 # スクリプトのあるディレクトリ
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "=== muhenkan-switch-rs インストーラー (macOS) ==="
+echo "=== muhenkan-switch インストーラー (macOS) ==="
 echo ""
 echo "アーキテクチャ: $ARCH"
 echo "インストール先: $INSTALL_DIR"
@@ -166,7 +166,7 @@ if [ "$install_agent" = "y" ] || [ "$install_agent" = "Y" ]; then
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.muhenkan-switch-rs.kanata</string>
+    <string>com.muhenkan-switch.kanata</string>
     <key>ProgramArguments</key>
     <array>
         <string>$INSTALL_DIR/muhenkan-switch</string>

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs インストールスクリプト (Linux)
+# muhenkan-switch インストールスクリプト (Linux)
 #
 # muhenkan-switch, config.toml, muhenkan.kbd をインストールし、
 # kanata を GitHub からダウンロードします。
@@ -11,14 +11,14 @@ set -euo pipefail
 KANATA_VERSION="v1.11.0"
 KANATA_ASSET="linux-binaries-x64.zip"
 KANATA_BINARY="kanata_linux_cmd_allowed_x64"
-INSTALL_DIR="$HOME/.local/share/muhenkan-switch-rs"
+INSTALL_DIR="$HOME/.local/share/muhenkan-switch"
 BIN_DIR="$HOME/.local/bin"
 
 # スクリプトのあるディレクトリ（展開した zip のルート）
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo ""
-echo "=== muhenkan-switch-rs インストーラー (Linux) ==="
+echo "=== muhenkan-switch インストーラー (Linux) ==="
 echo ""
 echo "インストール先: $INSTALL_DIR"
 echo "シンボリックリンク: $BIN_DIR"

--- a/scripts/install/uninstall-macos.sh
+++ b/scripts/install/uninstall-macos.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs アンインストールスクリプト (macOS)
+# muhenkan-switch アンインストールスクリプト (macOS)
 
-INSTALL_DIR="$HOME/Library/Application Support/muhenkan-switch-rs"
+INSTALL_DIR="$HOME/Library/Application Support/muhenkan-switch"
 BIN_DIR="$HOME/.local/bin"
 PLIST_DIR="$HOME/Library/LaunchAgents"
-PLIST_NAME="com.muhenkan-switch-rs.kanata.plist"
-LOG_DIR="$HOME/Library/Logs/muhenkan-switch-rs"
+PLIST_NAME="com.muhenkan-switch.kanata.plist"
+LOG_DIR="$HOME/Library/Logs/muhenkan-switch"
 
 echo ""
-echo "=== muhenkan-switch-rs アンインストーラー (macOS) ==="
+echo "=== muhenkan-switch アンインストーラー (macOS) ==="
 echo ""
 
 if [ ! -d "$INSTALL_DIR" ]; then
@@ -68,7 +68,7 @@ remove_symlink() {
             rm -f "$link_path"
             echo "[OK] シンボリックリンクを削除しました: $1"
         else
-            echo "[SKIP] $1 は muhenkan-switch-rs のリンクではありません (-> $target)"
+            echo "[SKIP] $1 は muhenkan-switch のリンクではありません (-> $target)"
         fi
     else
         echo "[SKIP] $1 はシンボリックリンクではないか、存在しません"

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs アンインストールスクリプト (Linux)
+# muhenkan-switch アンインストールスクリプト (Linux)
 
-INSTALL_DIR="$HOME/.local/share/muhenkan-switch-rs"
+INSTALL_DIR="$HOME/.local/share/muhenkan-switch"
 BIN_DIR="$HOME/.local/bin"
 SERVICE_FILE="$HOME/.config/systemd/user/kanata.service"
 AUTOSTART_FILE="$HOME/.config/autostart/muhenkan-switch.desktop"
@@ -11,7 +11,7 @@ APP_DESKTOP_FILE="$HOME/.local/share/applications/muhenkan-switch.desktop"
 ICON_FILE="$HOME/.local/share/icons/hicolor/128x128/apps/muhenkan-switch.png"
 
 echo ""
-echo "=== muhenkan-switch-rs アンインストーラー (Linux) ==="
+echo "=== muhenkan-switch アンインストーラー (Linux) ==="
 echo ""
 
 if [ ! -d "$INSTALL_DIR" ]; then
@@ -91,7 +91,7 @@ remove_symlink() {
             rm -f "$link_path"
             echo "[OK] シンボリックリンクを削除しました: $1"
         else
-            echo "[SKIP] $1 は muhenkan-switch-rs のリンクではありません (-> $target)"
+            echo "[SKIP] $1 は muhenkan-switch のリンクではありません (-> $target)"
         fi
     else
         echo "[SKIP] $1 はシンボリックリンクではないか、存在しません"

--- a/scripts/install/update-macos.sh
+++ b/scripts/install/update-macos.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs アップデートスクリプト (macOS)
+# muhenkan-switch アップデートスクリプト (macOS)
 #
 # GitHub Releases から最新版をダウンロードし、install-macos.sh を実行して更新します。
 
 # ── 設定 ──
-REPO="kimushun1101/muhenkan-switch-rs"
+REPO="kimushun1101/muhenkan-switch"
 
 # アーキテクチャ判定
 ARCH=$(uname -m)
 case "$ARCH" in
     arm64)
-        ASSET_NAME="muhenkan-switch-rs-macos-arm64.tar.gz"
+        ASSET_NAME="muhenkan-switch-macos-arm64.tar.gz"
         ;;
     x86_64)
-        ASSET_NAME="muhenkan-switch-rs-macos-x64.tar.gz"
+        ASSET_NAME="muhenkan-switch-macos-x64.tar.gz"
         ;;
     *)
         echo "[ERROR] 未対応のアーキテクチャです: $ARCH"
@@ -24,7 +24,7 @@ case "$ARCH" in
 esac
 
 echo ""
-echo "=== muhenkan-switch-rs アップデーター (macOS) ==="
+echo "=== muhenkan-switch アップデーター (macOS) ==="
 echo ""
 echo "アーキテクチャ: $ARCH"
 

--- a/scripts/install/update.sh
+++ b/scripts/install/update.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# muhenkan-switch-rs アップデートスクリプト (Linux)
+# muhenkan-switch アップデートスクリプト (Linux)
 #
 # GitHub Releases から最新版をダウンロードし、install.sh を実行して更新します。
 # root 権限は不要です。
 
 # ── 設定 ──
-REPO="kimushun1101/muhenkan-switch-rs"
-ASSET_NAME="muhenkan-switch-rs-linux-x64.tar.gz"
+REPO="kimushun1101/muhenkan-switch"
+ASSET_NAME="muhenkan-switch-linux-x64.tar.gz"
 
 echo ""
-echo "=== muhenkan-switch-rs アップデーター (Linux) ==="
+echo "=== muhenkan-switch アップデーター (Linux) ==="
 echo ""
 
 # ── 最新バージョンを取得 ──


### PR DESCRIPTION
## Summary
- GitHub URL / raw.githubusercontent.com URL を新リポジトリ名 `muhenkan-switch` に変更
- AHK 版への参照を `muhenkan-switch-ahk` に更新（README.md, legacy/README.md, docs/design.md）
- Linux/macOS インストールディレクトリを `muhenkan-switch-rs` → `muhenkan-switch` に統一
- macOS バンドル識別子を `com.muhenkan-switch-rs.kanata` → `com.muhenkan-switch.kanata` に統一
- リリースアセット名を `muhenkan-switch-*.tar.gz` に変更
- config コメントヘッダー、README タイトル、docs、LICENSE を更新
- 28 ファイル変更、全 46 テスト通過

## Test plan
- [x] `cargo test -p muhenkan-switch-config -p muhenkan-switch-core` — 全テスト通過
- [x] `grep -r "muhenkan-switch-rs"` — コードベース内に残存参照なし
- [ ] 次回リリース時に release.yml のアセット名・URL が正しく動作することを確認

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)