### PR TITLE
fix: Windows ビルド時の dead_code 警告を解消

### DIFF
--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -360,6 +360,7 @@ mod imp {
 
 /// file:// URI をパーセントデコードして PathBuf に変換する。
 /// パスが存在しない場合は None を返す。
+#[cfg(any(target_os = "linux", test))]
 fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
     let path_encoded = uri.strip_prefix("file://")?;
     let decoded = urlencoding::decode(path_encoded).ok()?;


### PR DESCRIPTION
## Summary
- `file_uri_to_path` 関数に `#[cfg(any(target_os = "linux", test))]` を追加
- Linux 固有コードからのみ呼ばれる関数が Windows ビルドで未使用警告を出していた問題を解消

## Test plan
- [x] `cargo check -p muhenkan-switch-core` で warning が出ないことを確認
- [x] `mise run dev` で正常動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)