### PR TITLE
fix: file_uri_to_path テストを全プラットフォーム対応に修正

### DIFF
--- a/muhenkan-switch-core/Cargo.toml
+++ b/muhenkan-switch-core/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "6"
 
 [dev-dependencies]
 indexmap = "2"
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -380,28 +380,35 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn file_uri_to_path_ascii() {
-        // /tmp は存在するはず
-        let result = file_uri_to_path("file:///tmp");
-        assert_eq!(result, Some(PathBuf::from("/tmp")));
+    fn file_uri_to_path_existing_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_owned();
+        let uri = format!("file://{}", path.display());
+        assert_eq!(file_uri_to_path(&uri), Some(path));
     }
 
     #[test]
     fn file_uri_to_path_encoded() {
-        // パーセントエンコードされた /tmp → デコードされて /tmp
-        let result = file_uri_to_path("file://%2Ftmp");
-        // %2F = '/' → "//tmp" — 存在するかは環境依存なので、デコード自体を検証
-        // /tmp はそのままでもテスト可能
-        assert!(result.is_some() || true); // デコードロジックが壊れないことを確認
+        // スペースを含むファイル名でパーセントエンコードを検証
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("hello world.txt");
+        std::fs::write(&file_path, "").unwrap();
+        let encoded_uri = format!(
+            "file://{}",
+            urlencoding::encode(&file_path.to_string_lossy())
+        );
+        assert_eq!(file_uri_to_path(&encoded_uri), Some(file_path));
+    }
 
-        // 存在しないパスは None
+    #[test]
+    fn file_uri_to_path_nonexistent() {
         let result = file_uri_to_path("file:///nonexistent_path_12345");
         assert_eq!(result, None);
     }
 
     #[test]
     fn file_uri_to_path_no_prefix() {
-        assert_eq!(file_uri_to_path("/tmp/file.txt"), None);
+        assert_eq!(file_uri_to_path("/nonexistent/file.txt"), None);
         assert_eq!(file_uri_to_path("https://example.com"), None);
     }
 


### PR DESCRIPTION
## Summary
- `/tmp` 依存のテストを `tempfile` クレートによる一時ファイルに置換し、Windows でも通るように修正
- パーセントエンコードのテストをスペース入りファイル名で実質的に検証するよう改善
- 常に true だった `assert!(result.is_some() || true)` を削除

Closes #110

## Test plan
- [x] `cargo test -p muhenkan-switch-core -- file_uri_to_path` で 4 件全て pass を確認（Windows）

🤖 Generated with [Claude Code](https://claude.com/claude-code)