### PR TITLE
feat: ydotool を削除し Wayland では PRIMARY セレクションで選択テキスト取得

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -92,15 +92,17 @@ sudo apt install xdotool wmctrl xclip x11-utils libnotify-bin
 
 | ツール | 用途 | インストール (Ubuntu) |
 |--------|------|----------------------|
-| ydotool | キー入力シミュレーション | `sudo apt install ydotool` |
-| wl-clipboard | ファイルマネージャのタイムスタンプ操作 | `sudo apt install wl-clipboard` |
+| wl-clipboard | 選択テキスト取得、ファイルマネージャ操作 | `sudo apt install wl-clipboard` |
 | notify-send | トースト通知 | `sudo apt install libnotify-bin` |
 
 ```bash
-sudo apt install ydotool wl-clipboard libnotify-bin
+sudo apt install wl-clipboard libnotify-bin
 ```
 
-> **Wayland の制限:** アプリ切り替え（wmctrl/xdotool 依存）とファイルマネージャの前面ウィンドウ検出（xprop 依存）は Wayland では動作しません。これらの機能を使うにはログイン画面で **「Ubuntu on Xorg」** を選択して X11 セッションに切り替えてください。
+> **Wayland の制限:** 以下の機能は Wayland では動作しません。全機能を使うにはログイン画面で **「Ubuntu on Xorg」** を選択して X11 セッションに切り替えてください。
+> - アプリ切り替え（wmctrl/xdotool 依存）
+> - ファイルマネージャの前面ウィンドウ検出（xprop 依存）
+> - タイムスタンプ入力（キー入力シミュレーション依存）
 
 ### Linux の追加設定
 

--- a/kanata/muhenkan.kbd
+++ b/kanata/muhenkan.kbd
@@ -10,9 +10,6 @@
 (defcfg
   process-unmapped-keys yes
   danger-enable-cmd yes
-  linux-dev-names-exclude (
-    "ydotool virtual device"
-  )
 )
 
 ;; ── ソースキー定義 ──

--- a/muhenkan-switch-core/src/commands/keys.rs
+++ b/muhenkan-switch-core/src/commands/keys.rs
@@ -8,6 +8,13 @@ pub fn simulate_type(text: &str) -> Result<()> {
     imp::simulate_type(text)
 }
 
+/// 選択中のテキストを取得する。
+/// Wayland: PRIMARY セレクションから直接読み取り（キー入力シミュレーション不要）
+/// X11/Windows/macOS: Ctrl+C シミュレート → CLIPBOARD から取得
+pub fn get_selected_text() -> Result<String> {
+    imp::get_selected_text()
+}
+
 // ── Platform: Windows ──
 
 #[cfg(target_os = "windows")]
@@ -21,6 +28,15 @@ mod imp {
 
     pub(super) fn simulate_copy() -> Result<()> {
         send_ctrl_key(VK_C)
+    }
+
+    pub(super) fn get_selected_text() -> Result<String> {
+        simulate_copy()?;
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let mut clipboard = arboard::Clipboard::new()?;
+        clipboard
+            .get_text()
+            .map_err(|e| anyhow::anyhow!("{}", e))
     }
 
     pub(super) fn simulate_type(text: &str) -> Result<()> {
@@ -116,40 +132,54 @@ mod imp {
         Ok(())
     }
 
-    fn run_ydotool(args: &[&str]) -> Result<()> {
-        Command::new("ydotool")
-            .args(args)
-            .output()
-            .context("ydotool が見つかりません。以下のコマンドでインストールしてください:\n  sudo apt install ydotool")?;
-        Ok(())
-    }
-
     pub(super) fn simulate_copy() -> Result<()> {
-        if super::super::is_wayland() {
-            run_ydotool(&["key", "ctrl+c"])
-        } else {
-            run_xdotool(&["key", "ctrl+c"])
-        }
+        run_xdotool(&["key", "ctrl+c"])
     }
 
     pub(super) fn simulate_type(text: &str) -> Result<()> {
-        // IME が有効だと xdotool type / ydotool type が全角入力になるため、
-        // クリップボード経由で貼り付ける（X11/Wayland 共通）
+        if super::super::is_wayland() {
+            anyhow::bail!(
+                "Wayland ではタイムスタンプ入力は未対応です。\n\
+                 X11 セッションに切り替えるか、手動で貼り付けてください。"
+            );
+        }
+        // IME が有効だと xdotool type が全角入力になるため、
+        // クリップボード経由で貼り付ける
         let mut clipboard = arboard::Clipboard::new()?;
         let saved = clipboard.get_text().ok();
         clipboard.set_text(text)?;
         std::thread::sleep(std::time::Duration::from_millis(50));
-        if super::super::is_wayland() {
-            run_ydotool(&["key", "ctrl+v"])?;
-        } else {
-            run_xdotool(&["key", "--clearmodifiers", "ctrl+v"])?;
-        }
+        run_xdotool(&["key", "--clearmodifiers", "ctrl+v"])?;
         std::thread::sleep(std::time::Duration::from_millis(100));
-        // クリップボードを復元
         if let Some(prev) = saved {
             let _ = clipboard.set_text(prev);
         }
         Ok(())
+    }
+
+    pub(super) fn get_selected_text() -> Result<String> {
+        if super::super::is_wayland() {
+            // PRIMARY セレクションから選択テキストを直接読み取り
+            let output = Command::new("wl-paste")
+                .args(["--primary", "--no-newline"])
+                .output()
+                .context(
+                    "wl-paste が見つかりません。以下のコマンドでインストールしてください:\n  \
+                     sudo apt install wl-clipboard",
+                )?;
+            if !output.status.success() {
+                anyhow::bail!("選択テキストの取得に失敗しました");
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            // X11: Ctrl+C → CLIPBOARD から取得
+            run_xdotool(&["key", "ctrl+c"])?;
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            let mut clipboard = arboard::Clipboard::new()?;
+            clipboard
+                .get_text()
+                .context("クリップボードにテキストがありません")
+        }
     }
 }
 
@@ -168,6 +198,15 @@ mod imp {
             ])
             .output()?;
         Ok(())
+    }
+
+    pub(super) fn get_selected_text() -> Result<String> {
+        simulate_copy()?;
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let mut clipboard = arboard::Clipboard::new()?;
+        clipboard
+            .get_text()
+            .map_err(|e| anyhow::anyhow!("{}", e))
     }
 
     pub(super) fn simulate_type(text: &str) -> Result<()> {

--- a/muhenkan-switch-core/src/commands/search.rs
+++ b/muhenkan-switch-core/src/commands/search.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use arboard::Clipboard;
 
 use crate::config::{self, Config};
 
@@ -7,23 +6,11 @@ pub fn run(engine: &str, config: &Config) -> Result<()> {
     // 検索エンジンのURLテンプレートを取得
     let url_template = config::get_search_url(&config.search, engine)?;
 
-    // 元のクリップボードを保存
-    let mut clipboard = Clipboard::new()?;
-    let saved = clipboard.get_text().ok();
-
-    // 選択テキストをクリップボードにコピー（Ctrl+C シミュレート）
-    super::keys::simulate_copy()?;
-    std::thread::sleep(std::time::Duration::from_millis(200));
-
-    // クリップボードからテキスト取得
-    let query = clipboard.get_text()?;
+    // 選択テキストを取得
+    let query = super::keys::get_selected_text()?;
 
     if query.trim().is_empty() {
-        // 復元してから返す
-        if let Some(text) = saved {
-            let _ = clipboard.set_text(text);
-        }
-        eprintln!("Warning: Clipboard is empty or contains no text.");
+        eprintln!("Warning: 選択テキストが空です。");
         return Ok(());
     }
 
@@ -31,11 +18,6 @@ pub fn run(engine: &str, config: &Config) -> Result<()> {
     let encoded = urlencoding::encode(query.trim());
     let url = url_template.replace("{query}", &encoded);
     webbrowser::open(&url)?;
-
-    // クリップボードを復元
-    if let Some(text) = saved {
-        let _ = clipboard.set_text(text);
-    }
 
     Ok(())
 }

--- a/muhenkan-switch-core/src/commands/timestamp.rs
+++ b/muhenkan-switch-core/src/commands/timestamp.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use arboard::Clipboard;
 use chrono::Local;
 use std::path::{Path, PathBuf};
@@ -84,14 +84,11 @@ fn format_toast_result(result: &Result<Vec<PathBuf>>) -> String {
 
 /// C: 選択テキストをプレーンテキストとしてクリップボードにコピー
 fn plain_copy() -> Result<()> {
-    // Ctrl+C で選択テキストをクリップボードにコピー
-    super::keys::simulate_copy()?;
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    // クリップボードからテキストのみ取得し、プレーンテキストとして再設定
+    let text = super::keys::get_selected_text()?;
+    if text.is_empty() {
+        anyhow::bail!("選択テキストが空です");
+    }
     let mut clipboard = Clipboard::new()?;
-    let text = clipboard
-        .get_text()
-        .context("クリップボードにテキストがありません")?;
     clipboard.set_text(&text)?;
     Ok(())
 }

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -204,7 +204,7 @@ echo "     $APP_DESKTOP_FILE"
 # ── 外部ツールの確認 ──
 missing_tools=""
 if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; then
-    for tool in ydotool wl-paste notify-send; do
+    for tool in wl-paste notify-send; do
         if ! command -v "$tool" &>/dev/null; then
             missing_tools="$missing_tools $tool"
         fi
@@ -214,7 +214,7 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; then
         echo "[WARNING] 以下の推奨ツールがインストールされていません:$missing_tools"
         echo "          一部の機能（キー入力シミュレーション・タイムスタンプ操作・通知）が動作しません。"
         echo ""
-        echo "  sudo apt install ydotool wl-clipboard libnotify-bin"
+        echo "  sudo apt install wl-clipboard libnotify-bin"
         echo ""
     fi
 else


### PR DESCRIPTION
## Summary
- ydotool 依存を完全削除（IME 不整合問題 #101 の根本解決）
- Wayland では `wl-paste --primary` で PRIMARY セレクションから選択テキストを直接取得（キー入力シミュレーション不要）
- `get_selected_text()` を新設し、search.rs / timestamp.rs をシンプル化
- タイムスタンプ入力（V）は Wayland では未対応（メッセージ表示）

### 変更前後の比較

| 機能 | 変更前 (ydotool) | 変更後 (PRIMARY) |
|------|-----------------|-----------------|
| Web 検索 (Q/R/W/G/B) | ydotool key ctrl+c → CLIPBOARD | wl-paste --primary（キー入力不要） |
| プレーンコピー (C) | ydotool key ctrl+c → CLIPBOARD | wl-paste --primary（キー入力不要） |
| タイムスタンプ入力 (V) | ydotool key ctrl+v（IME 問題あり） | 未対応メッセージ |
| 外部依存 | ydotool + wl-clipboard | wl-clipboard のみ |
| kanata 設定 | ydotool virtual device 除外が必要 | 不要 |

Closes #101

## Test plan
- [x] X11: Web 検索（無変換+Q）が動作すること
- [x] X11: プレーンコピー（無変換+C）が動作すること
- [x] X11: タイムスタンプ入力（無変換+V）が動作すること
- [x] Wayland: Web 検索（無変換+Q）が wl-paste 経由で動作すること
- [x] Wayland: プレーンコピー（無変換+C）が wl-paste 経由で動作すること
- [x] Wayland: タイムスタンプ入力（無変換+V）が未対応メッセージを表示すること
- [x] `cargo test -p muhenkan-switch-core` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)