### PR TITLE
fix: アップデートチェック CI の権限不足とバージョン取得バグを修正

### DIFF
--- a/.github/workflows/check-kanata-update.yml
+++ b/.github/workflows/check-kanata-update.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 0 * * 1'
   workflow_dispatch: # 手動実行も可能
 
+permissions:
+  issues: write
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-rust-update.yml
+++ b/.github/workflows/check-rust-update.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -22,8 +25,8 @@ jobs:
       - name: Get latest stable Rust version
         id: latest
         run: |
-          # major.minor のみ取得 (パッチは無視)
-          full=$(curl -sSf https://static.rust-lang.org/dist/channel-rust-stable.toml | grep -m1 '^version' | sed 's/version = "\(.*\)"/\1/')
+          # [pkg.rust] セクションの version を取得 (major.minor のみ)
+          full=$(curl -sSf https://static.rust-lang.org/dist/channel-rust-stable.toml | sed -n '/^\[pkg\.rust\]/,/^\[/p' | grep -m1 '^version' | sed 's/version = "\(.*\)"/\1/')
           version=$(echo "$full" | cut -d. -f1,2)
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "full=$full" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Rust/kanata アップデートチェックワークフローに `permissions: issues: write` を追加し、`gh issue create` の権限エラー (`Resource not accessible by integration`) を解消
- Rust 最新バージョン取得で `[pkg.rust]` セクションに限定し、別コンポーネントのバージョンを誤取得していたバグを修正

## Test plan
- [x] `check-rust-update` ワークフローを手動実行 (`workflow_dispatch`) して正しいバージョンが取得されることを確認
- [x] `check-kanata-update` ワークフローを手動実行して issue が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)