### PR TITLE
feat: Rust バージョンを 1.94 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "indexmap 2.13.0",
  "muhenkan-switch-config",
  "open",
+ "tempfile",
  "urlencoding",
  "webbrowser",
  "windows",

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@
 #   mise run gen-icons   img/icon.svg からアイコン全サイズを生成
 
 [tools]
-rust = "1.93"
+rust = "1.94"
 node = "lts"
 
 [tasks.setup]


### PR DESCRIPTION
## Summary
- `mise.toml` の Rust バージョンを `1.93` → `1.94` に更新
- `Cargo.lock` を更新

Closes #114

## Test plan
- [x] `mise install` で Rust 1.94 がインストールされることを確認
- [x] `cargo test --workspace` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)