### PR TITLE
feat: アプリプリセットに Brave / Ghostty を追加し不要なプリセットを整理

### DIFF
--- a/config/app-presets.json
+++ b/config/app-presets.json
@@ -55,6 +55,7 @@
     "ターミナル": [
       { "label": "Terminal", "process": "Terminal", "command": "open -a Terminal" },
       { "label": "iTerm2", "process": "iTerm2", "command": "open -a iTerm" },
+      { "label": "Ghostty", "process": "Ghostty", "command": "open -a Ghostty" },
       { "label": "Alacritty", "process": "alacritty", "command": "open -a Alacritty" }
     ]
   },
@@ -82,9 +83,8 @@
     ],
     "ターミナル": [
       { "label": "GNOME Terminal", "process": "gnome-terminal", "command": "gnome-terminal" },
-      { "label": "Terminator", "process": "terminator", "command": "terminator" },
-      { "label": "Alacritty", "process": "alacritty", "command": "alacritty" },
-      { "label": "Kitty", "process": "kitty", "command": "kitty" }
+      { "label": "Ghostty", "process": "ghostty", "command": "ghostty" },
+      { "label": "Alacritty", "process": "alacritty", "command": "alacritty" }
     ]
   }
 }

--- a/config/app-presets.json
+++ b/config/app-presets.json
@@ -8,6 +8,7 @@
     "ブラウザ": [
       { "label": "Edge", "process": "msedge", "command": "msedge" },
       { "label": "Chrome", "process": "chrome", "command": "chrome" },
+      { "label": "Brave", "process": "brave", "command": "brave" },
       { "label": "Firefox", "process": "firefox", "command": "firefox" },
       { "label": "Zen", "process": "zen", "command": "zen" }
     ],
@@ -36,6 +37,7 @@
     "ブラウザ": [
       { "label": "Safari", "process": "Safari", "command": "open -a Safari" },
       { "label": "Chrome", "process": "Google Chrome", "command": "open -a 'Google Chrome'" },
+      { "label": "Brave", "process": "Brave Browser", "command": "open -a 'Brave Browser'" },
       { "label": "Firefox", "process": "firefox", "command": "open -a Firefox" },
       { "label": "Zen", "process": "zen", "command": "open -a 'Zen Browser'" }
     ],
@@ -60,11 +62,12 @@
     "エディタ": [
       { "label": "VS Code", "process": "code", "command": "code" },
       { "label": "Cursor", "process": "cursor", "command": "cursor" },
-      { "label": "Zed", "process": "zed", "command": "zed" }
+      { "label": "Zed", "process": "zed", "command": "zed-editor" }
     ],
     "ブラウザ": [
       { "label": "Firefox", "process": "firefox", "command": "firefox" },
       { "label": "Chrome", "process": "google-chrome", "command": "google-chrome" },
+      { "label": "Brave", "process": "brave-browser", "command": "brave-browser" },
       { "label": "Zen", "process": "zen", "command": "zen" }
     ],
     "Document": [
@@ -79,6 +82,7 @@
     ],
     "ターミナル": [
       { "label": "GNOME Terminal", "process": "gnome-terminal", "command": "gnome-terminal" },
+      { "label": "Terminator", "process": "terminator", "command": "terminator" },
       { "label": "Alacritty", "process": "alacritty", "command": "alacritty" },
       { "label": "Kitty", "process": "kitty", "command": "kitty" }
     ]


### PR DESCRIPTION
## Summary

- **Brave** を全 OS（Windows / macOS / Linux）のブラウザプリセットに追加
- **Ghostty** を macOS / Linux のターミナルプリセットに追加（Windows は未対応のため除外）
- **Terminator / Kitty** を Linux のターミナルプリセットから削除
- **Zed (Linux)** の command を `zed` → `zed-editor` に修正（`zed` は別パッケージと競合する場合がある）

Closes #119

## Test plan

- [x] `cargo test --workspace` 全テスト通過
- [x] GUI のアプリタブで Brave / Ghostty がプリセット選択肢に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)