### PR TITLE
Rust を 1.95 に更新

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@
 #   mise run gen-icons   img/icon.svg からアイコン全サイズを生成
 
 [tools]
-rust = "1.94"
+rust = "1.95"
 node = "lts"
 
 [tasks.setup]


### PR DESCRIPTION
## Summary
- `mise.toml` の `rust` を `1.94` → `1.95` に更新
- リリースノート (https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/) を確認、本ワークスペースに影響する破壊的変更はなし

## Test plan
- [x] `mise install` で Rust 1.95.0 をセットアップ
- [x] `cargo build --workspace --all-targets` 警告なしで成功
- [x] `cargo test --workspace` 全テストパス (muhenkan-switch-config 29 / muhenkan-switch-core 27 / muhenkan-switch すべて ok)

Closes #129