### PR TITLE
chore(frontend): state.js の dead code 削除と vite.config.js の base 明示 (#138)

### DIFF
--- a/muhenkan-switch/frontend/src/lib/state.js
+++ b/muhenkan-switch/frontend/src/lib/state.js
@@ -1,10 +1,9 @@
 // ── Shared mutable state across form modules ──
-// 元 main.js の `let config`, `guiSettings`, `APP_PRESETS`, `SEARCH_PRESETS` 相当。
+// 元 main.js の `let config`, `APP_PRESETS`, `SEARCH_PRESETS` 相当。
 // ESM の `let` 直 export は import 側で再代入できないので、
 // getter / setter 関数経由でアクセスする (振る舞いは元コードと同一)。
 
 let config = null; // Current config from backend
-let guiSettings = {}; // GUI-only settings
 let APP_PRESETS = {};
 let SEARCH_PRESETS = {};
 
@@ -14,14 +13,6 @@ export function getConfig() {
 
 export function setConfig(next) {
   config = next;
-}
-
-export function getGuiSettings() {
-  return guiSettings;
-}
-
-export function setGuiSettings(next) {
-  guiSettings = next;
 }
 
 export function getAppPresets() {

--- a/muhenkan-switch/frontend/vite.config.js
+++ b/muhenkan-switch/frontend/vite.config.js
@@ -6,6 +6,8 @@ const host = process.env.TAURI_DEV_HOST;
 // Vite config for Tauri v2 (Phase 1: Vanilla JS, no @tauri-apps/api yet)
 // See: https://v2.tauri.app/start/frontend/vite/
 export default defineConfig({
+  // Tauri 環境で相対パス解決するため (defensive)
+  base: './',
   // Tauri CLI が出力をパースしやすくするため画面クリアを抑制
   clearScreen: false,
   server: {


### PR DESCRIPTION
## 概要

Phase 1 PR #137 のレビューで指摘され Phase 2 持ち越しになっていた、軽微な 2 件のフロントエンド改善。

### 1. `muhenkan-switch/frontend/src/lib/state.js` の dead code 削除

元 `main.js` から `state.js` に分割移植した際に残った未使用シンボル 3 つを削除:

- `let guiSettings = {};`
- `export function getGuiSettings()`
- `export function setGuiSettings(next)`

`grep -r 'guiSettings\|GuiSettings' muhenkan-switch/frontend/src/` で外部参照ゼロを事前/事後確認済み。冒頭コメントの `guiSettings` 言及も併せて削除。

### 2. `muhenkan-switch/frontend/vite.config.js` に `base: './'` を明示

Tauri 環境 (`tauri://localhost` 等) で生成 HTML のアセット参照を相対パス解決させるための defensive な設定。

ビルド前: `<script src=\"/assets/main-xxx.js\">` (絶対パス)
ビルド後: `<script src=\"./assets/main-xxx.js\">` (相対パス) を確認済み。

## 動作確認

- [x] `grep` で `guiSettings` 参照ゼロを事前/事後再確認
- [x] `npm --prefix muhenkan-switch/frontend run build` 成功 (`dist/index.html`, `dist/help.html` 生成)
- [x] `dist/*.html` のアセット参照が `./assets/...` (相対パス) になっていることを確認
- [ ] `mise run build` (cargo + frontend 統合ビルド) は Architect 側で別途確認

Closes #138