### PR TITLE
refactor(frontend): config-io.js の forms/* 依存方向を整理 (#140)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/apps.js
+++ b/muhenkan-switch/frontend/src/forms/apps.js
@@ -52,6 +52,30 @@ export function renderAppsList() {
   }
 }
 
+// Collect apps-list rows into the shared collected object.
+// Mirrors the original logic from lib/config-io.js so behavior is unchanged.
+// 機能名の重複を防ぐ（IndexMap のキー重複で上書きされるのを回避）
+export function collectApps(collected) {
+  for (const row of document.querySelectorAll("#apps-list .list-row")) {
+    let name = row.querySelector(".key-input").value.trim();
+    const appSelect = row.querySelector(".app-select");
+    const process = appSelect.value;
+    const selectedOpt = appSelect.options[appSelect.selectedIndex];
+    const command = selectedOpt?.dataset?.command || "";
+    const dispatchKey = row.querySelector(".dispatch-key-select").value;
+    if (name && process) {
+      if (collected.apps[name]) {
+        const appLabel = selectedOpt?.textContent || process;
+        name = `${name} (${appLabel})`;
+      }
+      const entry = { process };
+      if (dispatchKey) entry.key = dispatchKey;
+      if (command) entry.command = command;
+      collected.apps[name] = entry;
+    }
+  }
+}
+
 export function addAppRow(container, name = "", process = "", command = "", dispatchKey = "") {
   const row = document.createElement("div");
   row.className = "list-row";

--- a/muhenkan-switch/frontend/src/forms/folders.js
+++ b/muhenkan-switch/frontend/src/forms/folders.js
@@ -13,6 +13,21 @@ export function renderFoldersList() {
   }
 }
 
+// Collect folders-list rows into the shared collected object.
+// Mirrors the original logic from lib/config-io.js so behavior is unchanged.
+export function collectFolders(collected) {
+  for (const row of document.querySelectorAll("#folders-list .list-row")) {
+    const name = row.querySelector(".key-input").value.trim();
+    const path = row.querySelector(".path-input").value.trim();
+    const dispatchKey = row.querySelector(".dispatch-key-select").value;
+    if (name) {
+      const entry = { path };
+      if (dispatchKey) entry.key = dispatchKey;
+      collected.folders[name] = entry;
+    }
+  }
+}
+
 export function addFolderRow(container, name = "", path = "", dispatchKey = "") {
   const row = document.createElement("div");
   row.className = "list-row";

--- a/muhenkan-switch/frontend/src/forms/search.js
+++ b/muhenkan-switch/frontend/src/forms/search.js
@@ -12,6 +12,21 @@ export function renderSearchList() {
   }
 }
 
+// Collect search-list rows into the shared collected object.
+// Mirrors the original logic from lib/config-io.js so behavior is unchanged.
+export function collectSearch(collected) {
+  for (const row of document.querySelectorAll("#search-list .list-row")) {
+    const name = row.querySelector(".key-input").value.trim();
+    const url = row.querySelector(".url-input").value.trim();
+    const dispatchKey = row.querySelector(".dispatch-key-select").value;
+    if (name && url) {
+      const entry = { url };
+      if (dispatchKey) entry.key = dispatchKey;
+      collected.search[name] = entry;
+    }
+  }
+}
+
 export function addSearchRow(container, name = "", url = "", dispatchKey = "") {
   const row = document.createElement("div");
   row.className = "list-row";

--- a/muhenkan-switch/frontend/src/forms/timestamp.js
+++ b/muhenkan-switch/frontend/src/forms/timestamp.js
@@ -56,6 +56,16 @@ export function getTimestampDelimiter() {
   return preset;
 }
 
+// Collect timestamp settings into the shared collected object.
+// Mirrors the original logic from lib/config-io.js so behavior is unchanged.
+export function collectTimestamp(collected) {
+  collected.timestamp = {
+    format: getTimestampFormat(),
+    position: document.querySelector('input[name="ts-position"]:checked').value,
+    delimiter: getTimestampDelimiter(),
+  };
+}
+
 export async function updateTimestampPreview() {
   const format = getTimestampFormat();
   const delimiter = getTimestampDelimiter();

--- a/muhenkan-switch/frontend/src/lib/config-io.js
+++ b/muhenkan-switch/frontend/src/lib/config-io.js
@@ -1,16 +1,24 @@
 // ── Config load / render / collect / apply / reset / defaults ──
+//
+// 依存方向: lib/config-io.js は forms/* を直接 import せず、
+// `initConfigIo({ renderers, collectors })` で受け取った関数群へ fan-out する
+// (Issue #140)。Phase 3 TS 化や Phase 4 単体テストでの差し替え/モックを
+// しやすくする目的の純リファクタ。
 import { invoke, message, ask } from "./tauri.js";
 import {
   getConfig, setConfig,
   setAppPresets, setSearchPresets,
 } from "./state.js";
 import { validateDispatchKeys } from "./dispatch-key.js";
-import {
-  renderTimestamp, getTimestampFormat, getTimestampDelimiter,
-} from "../forms/timestamp.js";
-import { renderSearchList } from "../forms/search.js";
-import { renderFoldersList } from "../forms/folders.js";
-import { renderAppsList } from "../forms/apps.js";
+
+// ── Renderer / collector registries (set via initConfigIo) ──
+let renderers = [];
+let collectors = [];
+
+export function initConfigIo({ renderers: r = [], collectors: c = [] } = {}) {
+  renderers = r;
+  collectors = c;
+}
 
 // ── Load config on startup ──
 export async function loadConfig() {
@@ -34,20 +42,11 @@ export function renderConfig() {
   const config = getConfig();
   if (!config) return;
 
-  // Punctuation style
+  // Punctuation style (lib/config-io が直接保持する唯一の DOM 操作)
   document.getElementById("punctuation-style").value = config.punctuation_style || "、。";
 
-  // Timestamp
-  renderTimestamp();
-
-  // Search engines
-  renderSearchList();
-
-  // Folders
-  renderFoldersList();
-
-  // Apps
-  renderAppsList();
+  // Fan out to per-form renderers (順序は main.js の初期化順)
+  for (const render of renderers) render();
 }
 
 // ── Collect config from UI ──
@@ -56,57 +55,12 @@ export function collectConfig() {
     search: {},
     folders: {},
     apps: {},
-    timestamp: {
-      format: getTimestampFormat(),
-      position: document.querySelector('input[name="ts-position"]:checked').value,
-      delimiter: getTimestampDelimiter(),
-    },
+    timestamp: {},
     punctuation_style: document.getElementById("punctuation-style").value || "、。",
   };
 
-  // Search
-  for (const row of document.querySelectorAll("#search-list .list-row")) {
-    const name = row.querySelector(".key-input").value.trim();
-    const url = row.querySelector(".url-input").value.trim();
-    const dispatchKey = row.querySelector(".dispatch-key-select").value;
-    if (name && url) {
-      const entry = { url };
-      if (dispatchKey) entry.key = dispatchKey;
-      collected.search[name] = entry;
-    }
-  }
-
-  // Folders
-  for (const row of document.querySelectorAll("#folders-list .list-row")) {
-    const name = row.querySelector(".key-input").value.trim();
-    const path = row.querySelector(".path-input").value.trim();
-    const dispatchKey = row.querySelector(".dispatch-key-select").value;
-    if (name) {
-      const entry = { path };
-      if (dispatchKey) entry.key = dispatchKey;
-      collected.folders[name] = entry;
-    }
-  }
-
-  // Apps — 機能名の重複を防ぐ（IndexMap のキー重複で上書きされるのを回避）
-  for (const row of document.querySelectorAll("#apps-list .list-row")) {
-    let name = row.querySelector(".key-input").value.trim();
-    const appSelect = row.querySelector(".app-select");
-    const process = appSelect.value;
-    const selectedOpt = appSelect.options[appSelect.selectedIndex];
-    const command = selectedOpt?.dataset?.command || "";
-    const dispatchKey = row.querySelector(".dispatch-key-select").value;
-    if (name && process) {
-      if (collected.apps[name]) {
-        const appLabel = selectedOpt?.textContent || process;
-        name = `${name} (${appLabel})`;
-      }
-      const entry = { process };
-      if (dispatchKey) entry.key = dispatchKey;
-      if (command) entry.command = command;
-      collected.apps[name] = entry;
-    }
-  }
+  // Fan out to per-form collectors
+  for (const collect of collectors) collect(collected);
 
   return collected;
 }

--- a/muhenkan-switch/frontend/src/main.js
+++ b/muhenkan-switch/frontend/src/main.js
@@ -6,11 +6,21 @@
 import { invoke } from "./lib/tauri.js";
 import { initTabs } from "./lib/tabs.js";
 import { initShortcuts } from "./lib/shortcuts.js";
-import { loadConfig, renderConfig, initConfigActions } from "./lib/config-io.js";
-import { initTimestampForm } from "./forms/timestamp.js";
-import { initSearchForm } from "./forms/search.js";
-import { initFoldersForm } from "./forms/folders.js";
-import { initAppsForm } from "./forms/apps.js";
+import {
+  loadConfig, renderConfig, initConfigActions, initConfigIo,
+} from "./lib/config-io.js";
+import {
+  initTimestampForm, renderTimestamp, collectTimestamp,
+} from "./forms/timestamp.js";
+import {
+  initSearchForm, renderSearchList, collectSearch,
+} from "./forms/search.js";
+import {
+  initFoldersForm, renderFoldersList, collectFolders,
+} from "./forms/folders.js";
+import {
+  initAppsForm, renderAppsList, collectApps,
+} from "./forms/apps.js";
 import {
   initGeneralForm, refreshKanataStatus, loadAutostart, initUpdater,
 } from "./forms/general.js";
@@ -24,6 +34,12 @@ async function init() {
   initFoldersForm();
   initAppsForm();
   initGeneralForm({ renderConfig });
+  // forms/* の render/collect を config-io に注入 (Issue #140 で依存方向を逆転)
+  // 順序は元の renderConfig() / collectConfig() の呼び出し順を保つこと
+  initConfigIo({
+    renderers: [renderTimestamp, renderSearchList, renderFoldersList, renderAppsList],
+    collectors: [collectTimestamp, collectSearch, collectFolders, collectApps],
+  });
   initConfigActions();
   initShortcuts();
 


### PR DESCRIPTION
## 概要

`muhenkan-switch/frontend/src/lib/config-io.js` が `forms/*` (timestamp / search / folders / apps) を直接 import している逆向き依存を解消する純リファクタ。Phase 3 TS 化や Phase 4 単体テスト時に `forms/*` をモック・差し替えしやすくする布石。

Closes #140

## 採用方針

A 案 (Issue 提案案) を採用: `forms/*` 各モジュールに `collect()` を新規 export し、`main.js` で render/collect 関数群を集約 → `lib/config-io.js` に `initConfigIo({ renderers, collectors })` で fan-out 注入する。

B 案 (`punctuation_style` の DOM 操作も `forms/*` に追い出す) は **採用せず**、`config-io.js` に残置した。理由:
- 受け入れ基準「`forms/*` への import がゼロ」は A 案だけで満たせる
- 追加の form モジュール新設はスコープ拡大になるためフォロー Issue 候補
- レビュー差分を最小化して純リファクタの確信度を上げる

## 変更内容

- `frontend/src/forms/timestamp.js`: `collectTimestamp(collected)` を新規 export
- `frontend/src/forms/search.js`: `collectSearch(collected)` を新規 export
- `frontend/src/forms/folders.js`: `collectFolders(collected)` を新規 export
- `frontend/src/forms/apps.js`: `collectApps(collected)` を新規 export (機能名重複時のラベル付き rename ロジックを保持)
- `frontend/src/lib/config-io.js`: `forms/*` への import を全削除、`initConfigIo({ renderers, collectors })` を追加、`renderConfig()` / `collectConfig()` を fan-out 化
- `frontend/src/main.js`: `initConfigIo({ ... })` 呼び出しで forms の render/collect を注入

## 動作変化なしの確認

`collectConfig()` の戻り値構造とキー順序が従来と同じであることを確認:

- 旧: `{ search:{}, folders:{}, apps:{}, timestamp:{ format, position, delimiter }, punctuation_style }`
- 新: 初期化で `timestamp:{}` を作り、`collectTimestamp(collected)` が `collected.timestamp = { format, position, delimiter }` で同等のオブジェクトを代入

呼び出し順 (timestamp → search → folders → apps) は `main.js` の `collectors` 配列順で従来 `collectConfig()` 内の記述順と一致。`renderConfig()` も同様に元の順序 (timestamp → search → folders → apps) を `renderers` 配列で再現。

`forms/apps.js` の機能名重複時の rename ロジックは `collectApps()` にそのまま移植 (コメント込み)。

## 受け入れ基準

- [x] `frontend/src/lib/config-io.js` から `forms/*` への import がゼロ
  - `grep -n "from \"\.\./forms" muhenkan-switch/frontend/src/lib/config-io.js` → 0 件
- [x] `npm --prefix muhenkan-switch/frontend run build` 成功 (vite, 27 modules transformed)
- [x] GUI 動作変化なし (純リファクタ、戻り値構造・呼び出し順保持)
- [ ] `mise run build` (cargo + frontend 統合) は Architect 側で確認予定
- [ ] 設定の保存・読込・リセット・初期値復元・タブ切替で全タブ正常表示 (動作確認は Architect 側)

## Phase 3 への布石

- `forms/*` が `render()` / `collect()` を export する独立モジュールとなり、TS 化時にモジュール単位で型を付けやすい
- 単体テスト (Vitest) で `forms/*` を個別にテスト可能、`config-io.js` も `initConfigIo` でモック差し替え可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)