### PR TITLE
feat(frontend): tsconfig + typecheck CI 投入 (Phase 3-pre, リネームなし) (#144)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm --prefix muhenkan-switch/frontend ci
 
+      - name: Typecheck frontend (tsc)
+        run: npm --prefix muhenkan-switch/frontend run typecheck
+
       - name: Build frontend (Vite)
         run: npm --prefix muhenkan-switch/frontend run build
 
@@ -141,6 +144,9 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm --prefix muhenkan-switch/frontend ci
+
+      - name: Typecheck frontend (tsc)
+        run: npm --prefix muhenkan-switch/frontend run typecheck
 
       - name: Build frontend (Vite)
         run: npm --prefix muhenkan-switch/frontend run build

--- a/muhenkan-switch/frontend/package-lock.json
+++ b/muhenkan-switch/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-shell": "~2.3.5"
       },
       "devDependencies": {
+        "typescript": "~5.9.3",
         "vite": "^5.4.0"
       }
     },
@@ -993,6 +994,20 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite": {

--- a/muhenkan-switch/frontend/package.json
+++ b/muhenkan-switch/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tauri-apps/api": "~2.10.1",
@@ -14,6 +15,7 @@
     "@tauri-apps/plugin-shell": "~2.3.5"
   },
   "devDependencies": {
+    "typescript": "~5.9.3",
     "vite": "^5.4.0"
   }
 }

--- a/muhenkan-switch/frontend/tsconfig.json
+++ b/muhenkan-switch/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Close #144

フロントエンド近代化 Phase 3-pre。**TypeScript の足場のみ**を整備し、既存 `.js` ファイルは 1 つもリネーム/改変しない。実際の `.ts` 化と `Config` interface 定義は #145 以降で扱う。

## 実装サマリ

### 1. `muhenkan-switch/frontend/tsconfig.json` (新規)

- `target: ES2022` / `module: ESNext` / `moduleResolution: Bundler`
- `allowJs: true` / `checkJs: false` (既存 `.js` は型チェック対象外)
- `noEmit: true` (Vite がバンドルするので tsc は出力しない)
- `lib: [ES2022, DOM, DOM.Iterable]`、`esModuleInterop`, `isolatedModules`, `resolveJsonModule`, `skipLibCheck`, `useDefineForClassFields`
- `strict` 系は **入れない** (Phase 3-B で全 `.ts` 化後に有効化する方針)
- `include: ["src/**/*"]` で範囲限定

### 2. `muhenkan-switch/frontend/package.json`

- `devDependencies` に `typescript: ~5.9.3` を追加 (Phase 1〜2 lessons の方針通り minor pin。`5.9.3` は `npm view typescript versions` 上の 5.x 系最新 patch)
- `scripts` に `"typecheck": "tsc --noEmit"` を追加
- `package-lock.json` も追従更新

### 3. `.github/workflows/release.yml`

- `build` / `build-windows-nsis` 両ジョブの `Install frontend dependencies` (npm ci) と `Build frontend (Vite)` の間に新規 step `Typecheck frontend (tsc)` を挿入
- 既存 `Setup Node.js` のキャッシュ設定 (cache-dependency-path: muhenkan-switch/frontend/package-lock.json) はそのまま流用される
- 注: 当リポは PR/push トリガの CI ワークフローを持たず、`release.yml` (タグ push) が唯一の Node セットアップ済みワークフロー。Issue 指示「既存の Node.js setup ステップの後に挿入」に従い、ここに乗せる方針で実装。新規 PR/CI ワークフロー作成はスコープ外と判断 (必要なら別 Issue で追跡)。

## 受け入れ基準

- [x] `cd muhenkan-switch/frontend && npm ci && npm run typecheck` ローカル green
- [x] `mise run build` がエラーなく通る (build 成果物 `bin/muhenkan-switch`, `bin/muhenkan-switch-core` 確認)
- [x] `mise run dev` で GUI 起動確認 (kanata プロセス起動 + entering the processing loop ログまで到達)
- [x] **既存 `.js` ファイルが 1 つもリネーム/改変されていないことを `git diff main --name-only` で確認**

## 検証結果

### npm ci → typecheck

```
> muhenkan-switch-frontend@0.0.0 typecheck
> tsc --noEmit
```
(出力 0 行 = エラーなし、終了コード 0)

### mise run build (末尾)

```
[build]    Compiling muhenkan-switch v0.9.1
[build]    Compiling muhenkan-switch-core v0.9.1
[build]     Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 37s
[build] Copied -> ./bin/muhenkan-switch-core
[build] Copied -> ./bin/muhenkan-switch
[build] Copied -> ./bin/muhenkan.kbd
[build] Created ./bin/config.toml from default
[build] Finished in 128.66s
Finished in 129.70s
```

### mise run dev (起動確認、抜粋)

```
[dev] [kanata] started (pid: 1483436)
[dev] kanata v1.11.0 starting
[dev] config file is valid
[dev] entering the processing loop
[dev] entering the event loop
[dev] Starting kanata proper
```
GUI ウィンドウ + kanata sidecar 双方 spawn を確認後、明示的に `pkill` で停止。

### `.js` リネームなし確認

```
$ git diff main --name-only
.github/workflows/release.yml
muhenkan-switch/frontend/package-lock.json
muhenkan-switch/frontend/package.json

$ git ls-files --others --exclude-standard
muhenkan-switch/frontend/tsconfig.json

$ git diff main --name-only | grep -E '\.(js|ts)$'
(no .js/.ts changes)
```

`.js`/`.ts` ファイルの変更/追加は 0 件。

## コミット

3 コミットに分割:

1. `f380b61` feat(frontend): tsconfig.json 追加 (allowJs/checkJs:false で .js 維持)
2. `0850696` chore(frontend): typescript ~5.9.3 と typecheck script 追加
3. `7dc4e3e` ci(release): frontend ビルド前に typecheck step を挿入

## やらないこと (Issue 指示通り)

- 既存 `.js` ファイルのリネーム / 改変
- `Config` interface 定義 (#145)
- `lib/tauri.js` の `.ts` 化 (#145)
- ESLint / Prettier / Vitest 投入 (Phase 4)