### PR TITLE
feat(ci): PR トリガー workflow を追加 (#152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,24 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+          cache-dependency-path: muhenkan-switch/frontend/package-lock.json
+
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      # tauri::generate_context! が frontendDist (./frontend/dist) の実在を要求するため、
+      # cargo check 前に frontend を build しておく
+      - name: Install frontend dependencies
+        run: npm --prefix muhenkan-switch/frontend ci
+
+      - name: Build frontend (Vite)
+        run: npm --prefix muhenkan-switch/frontend run build
 
       # tauri-build がビルド時に externalBin の実在を確認するため、
       # ダミー sidecar ファイルを用意する (CI では実バイナリ不要、空ファイルで十分)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  frontend-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+          cache-dependency-path: muhenkan-switch/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm --prefix muhenkan-switch/frontend ci
+
+      - name: Typecheck frontend (tsc)
+        run: npm --prefix muhenkan-switch/frontend run typecheck
+
+      - name: Build frontend (Vite)
+        run: npm --prefix muhenkan-switch/frontend run build
+
+  rust-check:
+    # Tauri GUI のクロス OS ビルドは重いので release.yml に委ね、CI では Linux のみ
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      # tauri-build がビルド時に externalBin の実在を確認するため、
+      # ダミー sidecar ファイルを用意する (CI では実バイナリ不要、空ファイルで十分)
+      - name: Prepare sidecar placeholders
+        shell: bash
+        run: |
+          mkdir -p muhenkan-switch/binaries
+          touch muhenkan-switch/binaries/muhenkan-switch-core-x86_64-unknown-linux-gnu
+          touch muhenkan-switch/binaries/kanata_cmd_allowed-x86_64-unknown-linux-gnu
+
+      - name: cargo check
+        run: cargo check --workspace
+
+      - name: cargo test
+        run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   frontend-check:
     strategy:


### PR DESCRIPTION
## 概要

PR / main push トリガーで実行される CI ワークフロー (`.github/workflows/ci.yml`) を新規追加し、frontend (3 OS) と Rust workspace (Linux) の検証を自動化する。

Closes #152
関連: Phase 4 親 Issue #151

## 変更内容

- `frontend-check` ジョブ: ubuntu / windows / macos の 3 OS マトリクス (`fail-fast: false`) で `npm ci` → `typecheck` → `vite build` を実行
- `rust-check` ジョブ: Linux で `cargo check --workspace` と `cargo test --workspace` を実行
- アクションバージョンは `release.yml` と統一 (`actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, `actions/setup-node@v4`)
- cargo cache を `Swatinem/rust-cache@v2` で有効化
- sidecar placeholder は `touch` で空ファイル作成 (CI では実バイナリ不要、`cargo build --release -p muhenkan-switch-core` を省略してビルド時間短縮)
- `permissions: contents: read` を明示 (release.yml と一貫した最小権限)
- `concurrency:` で同 PR の連続 push 時に古い run を cancel (push (main) は cancel しない設計で歴史保持)

## 動作確認

- ローカル YAML 構文チェック: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK
- ジョブ構成: `frontend-check` (3 OS) + `rust-check` (Linux 1) の計 4 ジョブを確認
- GH Actions 上の実行結果は本 PR の Checks 欄を参照
- ネガティブテスト (TS 型エラー / Rust エラー注入時に CI が fail することの確認) は本 PR スコープ外。Phase 4-B 以降の PR で実コード変更時に副次的に検証する想定
