### PR TITLE
chore(ci): actions/setup-node を v6、action-gh-release を v3 に bump (#154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: 'npm'
@@ -136,7 +136,7 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: 'npm'
@@ -229,7 +229,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             muhenkan-switch-*.tar.gz


### PR DESCRIPTION
## 概要

`actions/setup-node@v4` (Node.js 20 ランタイム) の deprecation 対応として、両 workflow の関連 action を Node.js 24 ランタイム対応版に bump する。

タイムライン:
- 2026-06-02: Node.js 24 強制移行
- 2026-09-16: Node.js 20 完全削除

## 変更内容

- `actions/setup-node@v4` → `@v6` (ci.yml × 2、release.yml × 2)
  - v5.0.0 で Node 24 ランタイム化、最新 floating major は v6 (v6.4.0 が最新リリース)
- `softprops/action-gh-release@v2` → `@v3` (release.yml × 1)
  - v3.0.0 リリースノートに「Node 20 → Node 24 ランタイム移行」と明記

## 互換性確認

- `frontend/package.json` に `packageManager` フィールドなし → v5+ の自動 packageManager 検出は発火しないため、既存の `cache: 'npm'` 明示と二重キャッシュ問題は起きない
- v6.0.0 の breaking change (automatic caching を npm のみに限定) は npm 利用前提の本リポジトリに影響なし

## 受け入れ基準

- [x] CI green
- [x] CI ジョブログから Node.js 20 deprecation 警告が消えていること
- [ ] release.yml の挙動は次回 tag push 時に検証 (PR では dry run なし)

Closes #154