### PR TITLE
feat(frontend): Phase 4-B — ESLint + Prettier 導入 (#156)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,10 @@
 *.sh text eol=lf
 # kanata-version.txt はシェルスクリプトから読まれるため LF
 kanata-version.txt text eol=lf
+# Prettier 整形対象ファイルは LF 統一 (.prettierrc.json の endOfLine: 'lf' との整合、
+# Windows checkout 時の CRLF 変換による format:check 失敗を防止)
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.html text eol=lf
+*.css text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Typecheck frontend (tsc)
         run: npm --prefix muhenkan-switch/frontend run typecheck
 
+      - name: Lint frontend (ESLint)
+        run: npm --prefix muhenkan-switch/frontend run lint
+
+      - name: Format check (Prettier)
+        run: npm --prefix muhenkan-switch/frontend run format:check
+
       - name: Build frontend (Vite)
         run: npm --prefix muhenkan-switch/frontend run build
 

--- a/muhenkan-switch/frontend/.prettierignore
+++ b/muhenkan-switch/frontend/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+package-lock.json

--- a/muhenkan-switch/frontend/.prettierrc.json
+++ b/muhenkan-switch/frontend/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/muhenkan-switch/frontend/eslint.config.js
+++ b/muhenkan-switch/frontend/eslint.config.js
@@ -1,0 +1,24 @@
+// eslint.config.js — Flat config (ESLint v10 + typescript-eslint v8)
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
+import globals from 'globals';
+
+export default tseslint.config(
+  { ignores: ['dist/', 'node_modules/', '*.config.js'] },
+
+  js.configs.recommended,
+  ...tseslint.configs.strict,
+  ...tseslint.configs.stylistic,
+
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.browser },
+    },
+  },
+
+  eslintConfigPrettier,
+);

--- a/muhenkan-switch/frontend/eslint.config.js
+++ b/muhenkan-switch/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import globals from 'globals';
 
 export default tseslint.config(
-  { ignores: ['dist/', 'node_modules/', '*.config.js'] },
+  { ignores: ['dist/**', 'node_modules/**', '**/*.config.js'] },
 
   js.configs.recommended,
   ...tseslint.configs.strict,

--- a/muhenkan-switch/frontend/help.html
+++ b/muhenkan-switch/frontend/help.html
@@ -1,143 +1,319 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>使い方 — muhenkan-switch</title>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
-      font-size: 13px;
-      color: #cdd6f4;
-      background: #1e1e2e;
-      line-height: 1.6;
-    }
-    .help { max-width: 800px; margin: 0 auto; padding: 20px 24px; }
-    h1 { font-size: 18px; font-weight: 700; margin-bottom: 16px; color: #89b4fa; }
-    h2 { font-size: 14px; font-weight: 600; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
-    section { margin-bottom: 20px; }
-    p { margin-bottom: 8px; }
-    table { width: 100%; border-collapse: collapse; font-size: 13px; }
-    th, td { text-align: left; padding: 6px 10px; border: 1px solid #45475a; }
-    th { background: #282840; font-weight: 600; color: #8888aa; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
-    td { background: #1a1a2e; }
-    td:first-child { white-space: nowrap; }
-    kbd {
-      display: inline-block; padding: 1px 6px;
-      font-family: "Cascadia Code", "Consolas", monospace; font-size: 12px;
-      background: #282840; border: 1px solid #45475a; border-radius: 3px; color: #f9e2af;
-    }
-    ol { padding-left: 20px; }
-    ol li { margin-bottom: 4px; }
-    code { font-family: "Cascadia Code", "Consolas", monospace; font-size: 12px; color: #8888aa; }
-    #keyboard-svg { overflow: hidden; cursor: grab; border-radius: 6px; }
-    #keyboard-svg.dragging { cursor: grabbing; }
-    #keyboard-svg svg { display: block; transform-origin: 0 0; }
-    #keyboard-svg-hint { font-size: 11px; color: #8888aa; margin-top: 4px; }
-    .legend { display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 12px; }
-    .legend-item { display: flex; align-items: center; gap: 4px; }
-    .legend-color { display: inline-block; width: 14px; height: 14px; min-width: 14px; min-height: 14px; border: 1px solid #45475a; border-radius: 2px; flex-shrink: 0; overflow: hidden; font-size: 0; }
-    .lc-folder   { background-color: #fff2cc !important; }
-    .lc-search   { background-color: #ffe6cc !important; }
-    .lc-app      { background-color: #f8cecc !important; }
-    .lc-ts       { background-color: #e1d5e7 !important; }
-    .lc-edit     { background-color: #dae8fc !important; }
-    .lc-unset    { background-color: #f5f5f5 !important; }
-    .lc-unused   { background-color: #d9d9d9 !important; }
-  </style>
-</head>
-<body>
-  <div class="help">
-    <h1>muhenkan-switch 使い方</h1>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>使い方 — muhenkan-switch</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          'Segoe UI',
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 13px;
+        color: #cdd6f4;
+        background: #1e1e2e;
+        line-height: 1.6;
+      }
+      .help {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px 24px;
+      }
+      h1 {
+        font-size: 18px;
+        font-weight: 700;
+        margin-bottom: 16px;
+        color: #89b4fa;
+      }
+      h2 {
+        font-size: 14px;
+        font-weight: 600;
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      section {
+        margin-bottom: 20px;
+      }
+      p {
+        margin-bottom: 8px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 6px 10px;
+        border: 1px solid #45475a;
+      }
+      th {
+        background: #282840;
+        font-weight: 600;
+        color: #8888aa;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      td {
+        background: #1a1a2e;
+      }
+      td:first-child {
+        white-space: nowrap;
+      }
+      kbd {
+        display: inline-block;
+        padding: 1px 6px;
+        font-family: 'Cascadia Code', 'Consolas', monospace;
+        font-size: 12px;
+        background: #282840;
+        border: 1px solid #45475a;
+        border-radius: 3px;
+        color: #f9e2af;
+      }
+      ol {
+        padding-left: 20px;
+      }
+      ol li {
+        margin-bottom: 4px;
+      }
+      code {
+        font-family: 'Cascadia Code', 'Consolas', monospace;
+        font-size: 12px;
+        color: #8888aa;
+      }
+      #keyboard-svg {
+        overflow: hidden;
+        cursor: grab;
+        border-radius: 6px;
+      }
+      #keyboard-svg.dragging {
+        cursor: grabbing;
+      }
+      #keyboard-svg svg {
+        display: block;
+        transform-origin: 0 0;
+      }
+      #keyboard-svg-hint {
+        font-size: 11px;
+        color: #8888aa;
+        margin-top: 4px;
+      }
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        font-size: 12px;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .legend-color {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        min-width: 14px;
+        min-height: 14px;
+        border: 1px solid #45475a;
+        border-radius: 2px;
+        flex-shrink: 0;
+        overflow: hidden;
+        font-size: 0;
+      }
+      .lc-folder {
+        background-color: #fff2cc !important;
+      }
+      .lc-search {
+        background-color: #ffe6cc !important;
+      }
+      .lc-app {
+        background-color: #f8cecc !important;
+      }
+      .lc-ts {
+        background-color: #e1d5e7 !important;
+      }
+      .lc-edit {
+        background-color: #dae8fc !important;
+      }
+      .lc-unset {
+        background-color: #f5f5f5 !important;
+      }
+      .lc-unused {
+        background-color: #d9d9d9 !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="help">
+      <h1>muhenkan-switch 使い方</h1>
 
-    <section>
-      <h2>キーボード配列</h2>
-      <p>無変換キーを押しながら使うキーの一覧です。色はカテゴリを表します。</p>
-      <div id="keyboard-svg" style="margin: 12px 0;"></div>
-      <p id="keyboard-svg-hint">ホイールで拡大縮小 / ドラッグで移動 / ダブルクリックでリセット</p>
-      <div class="legend">
-        <span class="legend-item"><span class="legend-color lc-folder">&nbsp;</span>フォルダ</span>
-        <span class="legend-item"><span class="legend-color lc-search">&nbsp;</span>検索</span>
-        <span class="legend-item"><span class="legend-color lc-app">&nbsp;</span>アプリ</span>
-        <span class="legend-item"><span class="legend-color lc-ts">&nbsp;</span>タイムスタンプ</span>
-        <span class="legend-item"><span class="legend-color lc-edit">&nbsp;</span>テキスト編集</span>
-        <span class="legend-item"><span class="legend-color lc-unset">&nbsp;</span>未設定</span>
-        <span class="legend-item"><span class="legend-color lc-unused">&nbsp;</span>未使用</span>
-      </div>
-    </section>
+      <section>
+        <h2>キーボード配列</h2>
+        <p>無変換キーを押しながら使うキーの一覧です。色はカテゴリを表します。</p>
+        <div id="keyboard-svg" style="margin: 12px 0"></div>
+        <p id="keyboard-svg-hint">ホイールで拡大縮小 / ドラッグで移動 / ダブルクリックでリセット</p>
+        <div class="legend">
+          <span class="legend-item"
+            ><span class="legend-color lc-folder">&nbsp;</span>フォルダ</span
+          >
+          <span class="legend-item"><span class="legend-color lc-search">&nbsp;</span>検索</span>
+          <span class="legend-item"><span class="legend-color lc-app">&nbsp;</span>アプリ</span>
+          <span class="legend-item"
+            ><span class="legend-color lc-ts">&nbsp;</span>タイムスタンプ</span
+          >
+          <span class="legend-item"
+            ><span class="legend-color lc-edit">&nbsp;</span>テキスト編集</span
+          >
+          <span class="legend-item"><span class="legend-color lc-unset">&nbsp;</span>未設定</span>
+          <span class="legend-item"><span class="legend-color lc-unused">&nbsp;</span>未使用</span>
+        </div>
+      </section>
 
-    <section>
-      <h2>概要</h2>
-      <p>
-        <strong>muhenkan-switch</strong> は、無変換キーをモディファイアキーとして活用するツールです。<br>
-        無変換キーを押しながら割り当てられたキーを押すことで、さまざまな操作をすばやく実行できます。
-      </p>
-    </section>
+      <section>
+        <h2>概要</h2>
+        <p>
+          <strong>muhenkan-switch</strong>
+          は、無変換キーをモディファイアキーとして活用するツールです。<br />
+          無変換キーを押しながら割り当てられたキーを押すことで、さまざまな操作をすばやく実行できます。
+        </p>
+      </section>
 
-    <section>
-      <h2>キー操作一覧</h2>
-      <table>
-        <thead>
-          <tr><th>キー</th><th>機能</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><kbd>無変換</kbd> + <kbd>割当キー</kbd></td><td>各タブで設定された操作を実行</td></tr>
-          <tr><td><kbd>無変換</kbd> + <kbd>V</kbd></td><td>テキスト入力時: プレーンテキスト貼り付け<br>エクスプローラー上: ファイル更新日時でリネーム</td></tr>
-          <tr><td><kbd>無変換</kbd> + <kbd>C</kbd></td><td>テキスト入力時: タイムスタンプ入力<br>エクスプローラー上: タイムスタンプ付きで複製</td></tr>
-          <tr><td><kbd>無変換</kbd> + <kbd>X</kbd></td><td>エクスプローラー上: ファイル名からタイムスタンプを除去</td></tr>
-          <tr><td><kbd>無変換</kbd> + <kbd>Z</kbd></td><td>タイムスタンプ位置を切替（前 ↔ 後）。例を Toast 表示</td></tr>
-        </tbody>
-      </table>
-    </section>
+      <section>
+        <h2>キー操作一覧</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>キー</th>
+              <th>機能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><kbd>無変換</kbd> + <kbd>割当キー</kbd></td>
+              <td>各タブで設定された操作を実行</td>
+            </tr>
+            <tr>
+              <td><kbd>無変換</kbd> + <kbd>V</kbd></td>
+              <td>
+                テキスト入力時: プレーンテキスト貼り付け<br />エクスプローラー上:
+                ファイル更新日時でリネーム
+              </td>
+            </tr>
+            <tr>
+              <td><kbd>無変換</kbd> + <kbd>C</kbd></td>
+              <td>
+                テキスト入力時: タイムスタンプ入力<br />エクスプローラー上: タイムスタンプ付きで複製
+              </td>
+            </tr>
+            <tr>
+              <td><kbd>無変換</kbd> + <kbd>X</kbd></td>
+              <td>エクスプローラー上: ファイル名からタイムスタンプを除去</td>
+            </tr>
+            <tr>
+              <td><kbd>無変換</kbd> + <kbd>Z</kbd></td>
+              <td>タイムスタンプ位置を切替（前 ↔ 後）。例を Toast 表示</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
-    <section>
-      <h2>設定画面のショートカット</h2>
-      <table>
-        <thead>
-          <tr><th>キー</th><th>機能</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><kbd>Ctrl</kbd> + <kbd>S</kbd></td><td>設定を適用（保存）</td></tr>
-          <tr><td><kbd>Ctrl</kbd> + <kbd>Q</kbd></td><td>アプリを終了</td></tr>
-          <tr><td><kbd>F1</kbd></td><td>この画面を表示</td></tr>
-          <tr><td><kbd>Escape</kbd></td><td>設定画面をトレイに格納 / ヘルプを閉じる</td></tr>
-        </tbody>
-      </table>
-    </section>
+      <section>
+        <h2>設定画面のショートカット</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>キー</th>
+              <th>機能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><kbd>Ctrl</kbd> + <kbd>S</kbd></td>
+              <td>設定を適用（保存）</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd> + <kbd>Q</kbd></td>
+              <td>アプリを終了</td>
+            </tr>
+            <tr>
+              <td><kbd>F1</kbd></td>
+              <td>この画面を表示</td>
+            </tr>
+            <tr>
+              <td><kbd>Escape</kbd></td>
+              <td>設定画面をトレイに格納 / ヘルプを閉じる</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
-    <section>
-      <h2>設定タブ</h2>
-      <table>
-        <thead>
-          <tr><th>タブ</th><th>説明</th></tr>
-        </thead>
-        <tbody>
-          <tr><td>タイムスタンプ</td><td>エクスプローラー上でファイル名に付与するタイムスタンプの設定（ファイル更新日時を使用）</td></tr>
-          <tr><td>フォルダ</td><td>無変換+キーでフォルダを開く設定</td></tr>
-          <tr><td>アプリ</td><td>無変換+キーでアプリを切り替え／起動する設定</td></tr>
-          <tr><td>検索</td><td>無変換+キーで選択テキストを検索エンジンで検索する設定</td></tr>
-        </tbody>
-      </table>
-    </section>
+      <section>
+        <h2>設定タブ</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>タブ</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>タイムスタンプ</td>
+              <td>
+                エクスプローラー上でファイル名に付与するタイムスタンプの設定（ファイル更新日時を使用）
+              </td>
+            </tr>
+            <tr>
+              <td>フォルダ</td>
+              <td>無変換+キーでフォルダを開く設定</td>
+            </tr>
+            <tr>
+              <td>アプリ</td>
+              <td>無変換+キーでアプリを切り替え／起動する設定</td>
+            </tr>
+            <tr>
+              <td>検索</td>
+              <td>無変換+キーで選択テキストを検索エンジンで検索する設定</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
-    <section>
-      <h2>更新方法</h2>
-      <p data-install="installer">
-        起動時に自動でアップデートを確認します。新しいバージョンがある場合は通知が表示され、ワンクリックで更新できます。<br>
-        トレイアイコンの「アップデートを確認...」から手動で確認することもできます。</p>
-      <p data-install="script">
-        インストール先フォルダの更新スクリプトを実行してください。最新版のダウンロードとインストールが自動で行われます。</p>
-    </section>
+      <section>
+        <h2>更新方法</h2>
+        <p data-install="installer">
+          起動時に自動でアップデートを確認します。新しいバージョンがある場合は通知が表示され、ワンクリックで更新できます。<br />
+          トレイアイコンの「アップデートを確認...」から手動で確認することもできます。
+        </p>
+        <p data-install="script">
+          インストール先フォルダの更新スクリプトを実行してください。最新版のダウンロードとインストールが自動で行われます。
+        </p>
+      </section>
 
-    <section>
-      <h2>アンインストール</h2>
-      <p data-install="installer">
-        「設定  &gt; アプリ &gt; インストールされているアプリ」から muhenkan-switch を削除してください。</p>
-      <p data-install="script">
-        インストール先フォルダのアンインストールスクリプトを実行してください。</p>
-    </section>
-  </div>
-  <script type="module" src="/src/help.ts"></script>
-</body>
+      <section>
+        <h2>アンインストール</h2>
+        <p data-install="installer">
+          「設定 &gt; アプリ &gt; インストールされているアプリ」から muhenkan-switch
+          を削除してください。
+        </p>
+        <p data-install="script">
+          インストール先フォルダのアンインストールスクリプトを実行してください。
+        </p>
+      </section>
+    </div>
+    <script type="module" src="/src/help.ts"></script>
+  </body>
 </html>

--- a/muhenkan-switch/frontend/index.html
+++ b/muhenkan-switch/frontend/index.html
@@ -1,157 +1,170 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>muhenkan-switch 設定</title>
-  <link rel="stylesheet" href="styles/main.css">
-</head>
-<body>
-  <div class="app">
-    <!-- Tab bar -->
-    <nav class="tabs">
-      <button class="tab active" data-tab="general">全般</button>
-      <button class="tab" data-tab="timestamp">タイムスタンプ</button>
-      <button class="tab" data-tab="folders">フォルダ</button>
-      <button class="tab" data-tab="apps">アプリ</button>
-      <button class="tab" data-tab="search">検索</button>
-    </nav>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>muhenkan-switch 設定</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <div class="app">
+      <!-- Tab bar -->
+      <nav class="tabs">
+        <button class="tab active" data-tab="general">全般</button>
+        <button class="tab" data-tab="timestamp">タイムスタンプ</button>
+        <button class="tab" data-tab="folders">フォルダ</button>
+        <button class="tab" data-tab="apps">アプリ</button>
+        <button class="tab" data-tab="search">検索</button>
+      </nav>
 
-    <!-- Tab panels -->
-    <div class="panels">
+      <!-- Tab panels -->
+      <div class="panels">
+        <!-- General -->
+        <div class="panel active" id="panel-general">
+          <h2>全般</h2>
 
-      <!-- General -->
-      <div class="panel active" id="panel-general">
-        <h2>全般</h2>
-
-        <fieldset>
-          <legend>起動</legend>
-          <label class="checkbox-label">
-            <input type="checkbox" id="opt-autostart">
-            ログイン時に自動起動（トレイ常駐）
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <legend>句読点</legend>
-          <p class="hint">無変換+「,」「.」で入力される句読点スタイル</p>
-          <select id="punctuation-style">
-            <option value="、。">、。（読点・句点）</option>
-            <option value="，．">，．（コンマ・ピリオド）</option>
-            <option value="，。">，。（コンマ・句点）</option>
-            <option value="、．">、．（読点・ピリオド）</option>
-          </select>
-        </fieldset>
-
-        <fieldset>
-          <legend>設定管理</legend>
-          <div class="button-row">
-            <button id="btn-export-config">エクスポート</button>
-            <button id="btn-import-config">インポート</button>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>ヘルプ</legend>
-          <div class="button-row">
-            <button id="btn-help">使い方</button>
-            <button id="btn-github">GitHub</button>
-            <button id="btn-open-dir">インストール先を開く</button>
-            <button id="btn-quit" class="btn-danger">終了</button>
-          </div>
-        </fieldset>
-
-      </div>
-
-      <!-- Timestamp -->
-      <div class="panel" id="panel-timestamp">
-        <h2>タイムスタンプ</h2>
-        <p class="hint">選択しているファイルやフォルダの名前にタイムスタンプを付与・除去します。<br>無変換+<code>V</code> 付与 / <code>C</code> 付与(コピー) / <code>X</code> 除去</p>
-
-        <div class="form-group">
-          <label for="ts-format">フォーマット</label>
-          <select id="ts-format-preset">
-            <option value="%Y%m%d">%Y%m%d (20260216) - 最も一般的</option>
-            <option value="%y%m%d">%y%m%d (260216) - コンパクト</option>
-            <option value="%Y-%m-%d">%Y-%m-%d (2026-02-16) - 視認性重視</option>
-            <option value="%Y%m%d_%H%M%S">%Y%m%d_%H%M%S (20260216_142530) - 日時付き</option>
-            <option value="custom">カスタム...</option>
-          </select>
-          <input type="text" id="ts-format-custom" placeholder="%Y%m%d" class="hidden">
-        </div>
-
-        <div class="form-group">
-          <label for="ts-delimiter">区切り文字</label>
-          <select id="ts-delimiter-preset">
-            <option value="_">_ (アンダースコア)</option>
-            <option value="-">- (ハイフン)</option>
-            <option value="">なし</option>
-            <option value="custom">カスタム...</option>
-          </select>
-          <input type="text" id="ts-delimiter-custom" placeholder="_" class="hidden" maxlength="3">
-        </div>
-
-        <div class="form-group">
-          <label>位置</label>
-          <div class="radio-group">
-            <label class="radio-label">
-              <input type="radio" name="ts-position" value="before" checked>
-              前 (タイムスタンプ＋ファイル名)
+          <fieldset>
+            <legend>起動</legend>
+            <label class="checkbox-label">
+              <input type="checkbox" id="opt-autostart" />
+              ログイン時に自動起動（トレイ常駐）
             </label>
-            <label class="radio-label">
-              <input type="radio" name="ts-position" value="after">
-              後 (ファイル名＋タイムスタンプ)
-            </label>
+          </fieldset>
+
+          <fieldset>
+            <legend>句読点</legend>
+            <p class="hint">無変換+「,」「.」で入力される句読点スタイル</p>
+            <select id="punctuation-style">
+              <option value="、。">、。（読点・句点）</option>
+              <option value="，．">，．（コンマ・ピリオド）</option>
+              <option value="，。">，。（コンマ・句点）</option>
+              <option value="、．">、．（読点・ピリオド）</option>
+            </select>
+          </fieldset>
+
+          <fieldset>
+            <legend>設定管理</legend>
+            <div class="button-row">
+              <button id="btn-export-config">エクスポート</button>
+              <button id="btn-import-config">インポート</button>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>ヘルプ</legend>
+            <div class="button-row">
+              <button id="btn-help">使い方</button>
+              <button id="btn-github">GitHub</button>
+              <button id="btn-open-dir">インストール先を開く</button>
+              <button id="btn-quit" class="btn-danger">終了</button>
+            </div>
+          </fieldset>
+        </div>
+
+        <!-- Timestamp -->
+        <div class="panel" id="panel-timestamp">
+          <h2>タイムスタンプ</h2>
+          <p class="hint">
+            選択しているファイルやフォルダの名前にタイムスタンプを付与・除去します。<br />無変換+<code
+              >V</code
+            >
+            付与 / <code>C</code> 付与(コピー) / <code>X</code> 除去
+          </p>
+
+          <div class="form-group">
+            <label for="ts-format">フォーマット</label>
+            <select id="ts-format-preset">
+              <option value="%Y%m%d">%Y%m%d (20260216) - 最も一般的</option>
+              <option value="%y%m%d">%y%m%d (260216) - コンパクト</option>
+              <option value="%Y-%m-%d">%Y-%m-%d (2026-02-16) - 視認性重視</option>
+              <option value="%Y%m%d_%H%M%S">%Y%m%d_%H%M%S (20260216_142530) - 日時付き</option>
+              <option value="custom">カスタム...</option>
+            </select>
+            <input type="text" id="ts-format-custom" placeholder="%Y%m%d" class="hidden" />
+          </div>
+
+          <div class="form-group">
+            <label for="ts-delimiter">区切り文字</label>
+            <select id="ts-delimiter-preset">
+              <option value="_">_ (アンダースコア)</option>
+              <option value="-">- (ハイフン)</option>
+              <option value="">なし</option>
+              <option value="custom">カスタム...</option>
+            </select>
+            <input
+              type="text"
+              id="ts-delimiter-custom"
+              placeholder="_"
+              class="hidden"
+              maxlength="3"
+            />
+          </div>
+
+          <div class="form-group">
+            <label>位置</label>
+            <div class="radio-group">
+              <label class="radio-label">
+                <input type="radio" name="ts-position" value="before" checked />
+                前 (タイムスタンプ＋ファイル名)
+              </label>
+              <label class="radio-label">
+                <input type="radio" name="ts-position" value="after" />
+                後 (ファイル名＋タイムスタンプ)
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label>プレビュー</label>
+            <div class="preview-box" id="ts-preview">-</div>
           </div>
         </div>
 
-        <div class="form-group">
-          <label>プレビュー</label>
-          <div class="preview-box" id="ts-preview">-</div>
+        <!-- Search -->
+        <div class="panel" id="panel-search">
+          <h2>検索エンジン</h2>
+          <p class="hint">
+            「選択」ボタンでプリセットから選べます。URL は直接編集も可能です。<code>{query}</code>
+            が選択テキストに置換されます。
+          </p>
+          <div class="dynamic-list" id="search-list"></div>
+          <button class="btn-add" id="btn-add-search">+ 追加</button>
+        </div>
+
+        <!-- Folders -->
+        <div class="panel" id="panel-folders">
+          <h2>フォルダ</h2>
+          <p class="hint"><code>~</code> はホームディレクトリに展開されます。</p>
+          <div class="dynamic-list" id="folders-list"></div>
+          <button class="btn-add" id="btn-add-folder">+ 追加</button>
+        </div>
+
+        <!-- Apps -->
+        <div class="panel" id="panel-apps">
+          <h2>アプリ切り替え</h2>
+          <p class="hint">
+            リストにないアプリや機能の追加は「選択」ボタンで実行中のプロセスから登録できます。
+          </p>
+          <div class="dynamic-list" id="apps-list"></div>
+          <button class="btn-add" id="btn-add-app">+ 追加</button>
         </div>
       </div>
 
-      <!-- Search -->
-      <div class="panel" id="panel-search">
-        <h2>検索エンジン</h2>
-        <p class="hint">「選択」ボタンでプリセットから選べます。URL は直接編集も可能です。<code>{query}</code> が選択テキストに置換されます。</p>
-        <div class="dynamic-list" id="search-list"></div>
-        <button class="btn-add" id="btn-add-search">+ 追加</button>
-      </div>
-
-      <!-- Folders -->
-      <div class="panel" id="panel-folders">
-        <h2>フォルダ</h2>
-        <p class="hint"><code>~</code> はホームディレクトリに展開されます。</p>
-        <div class="dynamic-list" id="folders-list"></div>
-        <button class="btn-add" id="btn-add-folder">+ 追加</button>
-      </div>
-
-      <!-- Apps -->
-      <div class="panel" id="panel-apps">
-        <h2>アプリ切り替え</h2>
-        <p class="hint">リストにないアプリや機能の追加は「選択」ボタンで実行中のプロセスから登録できます。</p>
-        <div class="dynamic-list" id="apps-list"></div>
-        <button class="btn-add" id="btn-add-app">+ 追加</button>
-      </div>
-
+      <!-- Status bar -->
+      <footer class="status-bar">
+        <div class="status-left">
+          <span id="footer-version">-</span>
+          <span class="status-dot" id="footer-kanata-dot"></span>
+          <span id="footer-kanata-text">キー割当: 停止中</span>
+        </div>
+        <div class="status-right">
+          <button id="btn-apply" class="btn-primary">適用</button>
+          <button id="btn-reset">リセット</button>
+          <button id="btn-defaults">初期値</button>
+        </div>
+      </footer>
     </div>
 
-    <!-- Status bar -->
-    <footer class="status-bar">
-      <div class="status-left">
-        <span id="footer-version">-</span>
-        <span class="status-dot" id="footer-kanata-dot"></span>
-        <span id="footer-kanata-text">キー割当: 停止中</span>
-      </div>
-      <div class="status-right">
-        <button id="btn-apply" class="btn-primary">適用</button>
-        <button id="btn-reset">リセット</button>
-        <button id="btn-defaults">初期値</button>
-      </div>
-    </footer>
-  </div>
-
-  <script type="module" src="src/main.ts"></script>
-</body>
+    <script type="module" src="src/main.ts"></script>
+  </body>
 </html>

--- a/muhenkan-switch/frontend/package-lock.json
+++ b/muhenkan-switch/frontend/package-lock.json
@@ -13,7 +13,13 @@
         "@tauri-apps/plugin-shell": "~2.3.5"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.0",
+        "eslint": "^10.3.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^16.0.0",
+        "prettier": "^3.8.3",
         "typescript": "~5.9.3",
+        "typescript-eslint": "^8.59.2",
         "vite": "^5.4.0"
       }
     },
@@ -406,6 +412,200 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -825,10 +1025,357 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -871,6 +1418,277 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -885,6 +1703,166 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -905,12 +1883,102 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.14",
@@ -939,6 +2007,42 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rollup": {
@@ -986,6 +2090,42 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -994,6 +2134,49 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {
@@ -1008,6 +2191,40 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -1068,6 +2285,45 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/muhenkan-switch/frontend/package.json
+++ b/muhenkan-switch/frontend/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@tauri-apps/api": "~2.10.1",
@@ -15,7 +19,13 @@
     "@tauri-apps/plugin-shell": "~2.3.5"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.0",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^16.0.0",
+    "prettier": "^3.8.3",
     "typescript": "~5.9.3",
+    "typescript-eslint": "^8.59.2",
     "vite": "^5.4.0"
   }
 }

--- a/muhenkan-switch/frontend/src/forms/apps.ts
+++ b/muhenkan-switch/frontend/src/forms/apps.ts
@@ -1,10 +1,10 @@
 // ── Apps form ──
-import { invoke } from "../lib/tauri";
-import { getConfig, getAppPresets } from "../lib/state";
-import { createDispatchKeySelect } from "../lib/dispatch-key";
-import { escapeHtml } from "../lib/utils";
-import type { AppEntry } from "../lib/config";
-import type { CollectedConfig } from "../lib/config-io";
+import { invoke } from '../lib/tauri';
+import { getConfig, getAppPresets } from '../lib/state';
+import { createDispatchKeySelect } from '../lib/dispatch-key';
+import { escapeHtml } from '../lib/utils';
+import type { AppEntry } from '../lib/config';
+import type { CollectedConfig } from '../lib/config-io';
 
 /** Tauri 側 ProcessInfo (commands.rs) と対応 */
 interface ProcessInfo {
@@ -13,26 +13,26 @@ interface ProcessInfo {
 }
 
 // ── App select dropdown helper ──
-export function createAppSelect(currentProcess: string = "", currentCommand: string = ""): HTMLSelectElement {
+export function createAppSelect(currentProcess = '', currentCommand = ''): HTMLSelectElement {
   const APP_PRESETS = getAppPresets();
-  const select = document.createElement("select");
-  select.className = "app-select";
+  const select = document.createElement('select');
+  select.className = 'app-select';
 
-  const noneOpt = document.createElement("option");
-  noneOpt.value = "";
-  noneOpt.textContent = "—";
+  const noneOpt = document.createElement('option');
+  noneOpt.value = '';
+  noneOpt.textContent = '—';
   select.appendChild(noneOpt);
 
   let hasCurrentProcess = !currentProcess;
 
   for (const [category, apps] of Object.entries(APP_PRESETS)) {
-    const group = document.createElement("optgroup");
+    const group = document.createElement('optgroup');
     group.label = category;
     for (const app of apps) {
-      const opt = document.createElement("option");
+      const opt = document.createElement('option');
       opt.value = app.process;
       opt.textContent = app.label;
-      opt.dataset["command"] = app.command;
+      opt.dataset['command'] = app.command;
       group.appendChild(opt);
       if (app.process === currentProcess) hasCurrentProcess = true;
     }
@@ -40,25 +40,25 @@ export function createAppSelect(currentProcess: string = "", currentCommand: str
   }
 
   if (currentProcess && !hasCurrentProcess) {
-    const opt = document.createElement("option");
+    const opt = document.createElement('option');
     opt.value = currentProcess;
     opt.textContent = `${currentProcess}（カスタム）`;
-    opt.dataset["command"] = currentCommand || currentProcess.toLowerCase();
+    opt.dataset['command'] = currentCommand || currentProcess.toLowerCase();
     select.appendChild(opt);
   }
 
-  select.value = currentProcess || "";
+  select.value = currentProcess || '';
   return select;
 }
 
 export function renderAppsList(): void {
   const config = getConfig();
   if (!config) return;
-  const container = document.getElementById("apps-list");
+  const container = document.getElementById('apps-list');
   if (!container) return;
-  container.innerHTML = "";
+  container.innerHTML = '';
   for (const [name, entry] of Object.entries(config.apps ?? {})) {
-    addAppRow(container, name, entry.process, entry.command ?? "", entry.key ?? "");
+    addAppRow(container, name, entry.process, entry.command ?? '', entry.key ?? '');
   }
 }
 
@@ -66,15 +66,15 @@ export function renderAppsList(): void {
 // Mirrors the original logic from lib/config-io.ts so behavior is unchanged.
 // 機能名の重複を防ぐ（IndexMap のキー重複で上書きされるのを回避）
 export function collectApps(collected: CollectedConfig): void {
-  for (const row of document.querySelectorAll<HTMLElement>("#apps-list .list-row")) {
-    const nameInput = row.querySelector<HTMLInputElement>(".key-input");
-    const appSelect = row.querySelector<HTMLSelectElement>(".app-select");
-    const keySelect = row.querySelector<HTMLSelectElement>(".dispatch-key-select");
+  for (const row of document.querySelectorAll<HTMLElement>('#apps-list .list-row')) {
+    const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+    const appSelect = row.querySelector<HTMLSelectElement>('.app-select');
+    const keySelect = row.querySelector<HTMLSelectElement>('.dispatch-key-select');
     if (!nameInput || !appSelect || !keySelect) continue;
     let name = nameInput.value.trim();
     const process = appSelect.value;
     const selectedOpt = appSelect.options[appSelect.selectedIndex] as HTMLOptionElement | undefined;
-    const command = selectedOpt?.dataset?.["command"] ?? "";
+    const command = selectedOpt?.dataset?.['command'] ?? '';
     const dispatchKey = keySelect.value;
     if (name && process) {
       if (collected.apps[name]) {
@@ -91,13 +91,13 @@ export function collectApps(collected: CollectedConfig): void {
 
 export function addAppRow(
   container: HTMLElement,
-  name: string = "",
-  process: string = "",
-  command: string = "",
-  dispatchKey: string = "",
+  name = '',
+  process = '',
+  command = '',
+  dispatchKey = '',
 ): void {
-  const row = document.createElement("div");
-  row.className = "list-row";
+  const row = document.createElement('div');
+  row.className = 'list-row';
   row.innerHTML = `
     <input type="text" class="key-input" placeholder="機能名" value="${escapeHtml(name)}">
     <button class="btn-pick-process" title="実行中のプロセスから選択">選択</button>
@@ -107,32 +107,37 @@ export function addAppRow(
   row.insertBefore(keySelect, row.firstChild);
 
   const appSelect = createAppSelect(process, command);
-  const nameInput = row.querySelector<HTMLInputElement>(".key-input");
+  const nameInput = row.querySelector<HTMLInputElement>('.key-input');
   if (!nameInput) return;
-  nameInput.insertAdjacentElement("afterend", appSelect);
+  nameInput.insertAdjacentElement('afterend', appSelect);
 
-  appSelect.addEventListener("change", () => {
+  appSelect.addEventListener('change', () => {
     const selected = appSelect.options[appSelect.selectedIndex] as HTMLOptionElement | undefined;
-    if (selected && selected.parentElement?.tagName === "OPTGROUP") {
+    if (selected && selected.parentElement?.tagName === 'OPTGROUP') {
       const parent = selected.parentElement as HTMLOptGroupElement;
       const category = parent.label;
-      nameInput.value = `${category} (${selected.textContent ?? ""})`;
+      nameInput.value = `${category} (${selected.textContent ?? ''})`;
     }
   });
 
-  row.querySelector<HTMLButtonElement>(".btn-remove")?.addEventListener("click", () => row.remove());
-  row.querySelector<HTMLButtonElement>(".btn-pick-process")?.addEventListener("click", async () => {
+  row
+    .querySelector<HTMLButtonElement>('.btn-remove')
+    ?.addEventListener('click', () => row.remove());
+  row.querySelector<HTMLButtonElement>('.btn-pick-process')?.addEventListener('click', async () => {
     const selected = await showProcessPicker();
     if (selected) {
       let found = false;
       for (const opt of appSelect.options) {
-        if (opt.value === selected) { found = true; break; }
+        if (opt.value === selected) {
+          found = true;
+          break;
+        }
       }
       if (!found) {
-        const opt = document.createElement("option");
+        const opt = document.createElement('option');
         opt.value = selected;
         opt.textContent = `${selected}（カスタム）`;
-        opt.dataset["command"] = selected.toLowerCase();
+        opt.dataset['command'] = selected.toLowerCase();
         appSelect.appendChild(opt);
       }
       appSelect.value = selected;
@@ -143,18 +148,17 @@ export function addAppRow(
 
 // ── Process picker modal ──
 export async function showProcessPicker(): Promise<string | null> {
-  return new Promise<string | null>(async (resolve) => {
-    let processes: ProcessInfo[] = [];
-    try {
-      processes = await invoke<ProcessInfo[]>("get_running_processes");
-    } catch (e) {
-      console.error("プロセス一覧の取得に失敗:", e);
-      resolve(null);
-      return;
-    }
+  let processes: ProcessInfo[] = [];
+  try {
+    processes = await invoke<ProcessInfo[]>('get_running_processes');
+  } catch (e) {
+    console.error('プロセス一覧の取得に失敗:', e);
+    return null;
+  }
 
-    const overlay = document.createElement("div");
-    overlay.className = "modal-overlay";
+  return new Promise<string | null>((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
     overlay.innerHTML = `
       <div class="modal">
         <div class="modal-header">プロセスを選択</div>
@@ -168,26 +172,24 @@ export async function showProcessPicker(): Promise<string | null> {
       </div>
     `;
 
-    const list = overlay.querySelector<HTMLUListElement>(".modal-list");
-    const searchInput = overlay.querySelector<HTMLInputElement>(".modal-search");
+    const list = overlay.querySelector<HTMLUListElement>('.modal-list');
+    const searchInput = overlay.querySelector<HTMLInputElement>('.modal-search');
     if (!list || !searchInput) {
       resolve(null);
       return;
     }
 
-    function renderProcessList(filter: string = ""): void {
+    function renderProcessList(filter = ''): void {
       if (!list) return;
-      list.innerHTML = "";
-      const filtered = processes.filter((p) =>
-        p.name.toLowerCase().includes(filter.toLowerCase())
-      );
+      list.innerHTML = '';
+      const filtered = processes.filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()));
       for (const p of filtered) {
-        const li = document.createElement("li");
+        const li = document.createElement('li');
         li.textContent = p.name;
-        li.addEventListener("click", () => {
+        li.addEventListener('click', () => {
           // Remove .exe extension
           let name = p.name;
-          if (name.toLowerCase().endsWith(".exe")) {
+          if (name.toLowerCase().endsWith('.exe')) {
             name = name.slice(0, -4);
           }
           close(name);
@@ -196,27 +198,29 @@ export async function showProcessPicker(): Promise<string | null> {
       }
     }
 
-    searchInput.addEventListener("input", (e) => {
+    searchInput.addEventListener('input', (e) => {
       const target = e.target as HTMLInputElement;
       renderProcessList(target.value);
     });
 
     function close(result: string | null): void {
       overlay.remove();
-      document.removeEventListener("keydown", onKeydown);
+      document.removeEventListener('keydown', onKeydown);
       resolve(result);
     }
 
-    overlay.querySelector<HTMLButtonElement>(".btn-cancel")?.addEventListener("click", () => close(null));
+    overlay
+      .querySelector<HTMLButtonElement>('.btn-cancel')
+      ?.addEventListener('click', () => close(null));
 
-    overlay.addEventListener("click", (e) => {
+    overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close(null);
     });
 
     function onKeydown(e: KeyboardEvent): void {
-      if (e.key === "Escape") close(null);
+      if (e.key === 'Escape') close(null);
     }
-    document.addEventListener("keydown", onKeydown);
+    document.addEventListener('keydown', onKeydown);
 
     renderProcessList();
     document.body.appendChild(overlay);
@@ -225,10 +229,10 @@ export async function showProcessPicker(): Promise<string | null> {
 }
 
 export function initAppsForm(): void {
-  const btn = document.getElementById("btn-add-app");
-  const list = document.getElementById("apps-list");
+  const btn = document.getElementById('btn-add-app');
+  const list = document.getElementById('apps-list');
   if (!btn || !list) return;
-  btn.addEventListener("click", () => {
+  btn.addEventListener('click', () => {
     addAppRow(list);
   });
 }

--- a/muhenkan-switch/frontend/src/forms/folders.ts
+++ b/muhenkan-switch/frontend/src/forms/folders.ts
@@ -1,29 +1,29 @@
 // ── Folders form ──
-import { invoke } from "../lib/tauri";
-import { getConfig } from "../lib/state";
-import { createDispatchKeySelect } from "../lib/dispatch-key";
-import { escapeHtml } from "../lib/utils";
-import type { FolderEntry } from "../lib/config";
-import type { CollectedConfig } from "../lib/config-io";
+import { invoke } from '../lib/tauri';
+import { getConfig } from '../lib/state';
+import { createDispatchKeySelect } from '../lib/dispatch-key';
+import { escapeHtml } from '../lib/utils';
+import type { FolderEntry } from '../lib/config';
+import type { CollectedConfig } from '../lib/config-io';
 
 export function renderFoldersList(): void {
   const config = getConfig();
   if (!config) return;
-  const container = document.getElementById("folders-list");
+  const container = document.getElementById('folders-list');
   if (!container) return;
-  container.innerHTML = "";
+  container.innerHTML = '';
   for (const [name, entry] of Object.entries(config.folders ?? {})) {
-    addFolderRow(container, name, entry.path, entry.key ?? "");
+    addFolderRow(container, name, entry.path, entry.key ?? '');
   }
 }
 
 // Collect folders-list rows into the shared collected object.
 // Mirrors the original logic from lib/config-io.ts so behavior is unchanged.
 export function collectFolders(collected: CollectedConfig): void {
-  for (const row of document.querySelectorAll<HTMLElement>("#folders-list .list-row")) {
-    const nameInput = row.querySelector<HTMLInputElement>(".key-input");
-    const pathInput = row.querySelector<HTMLInputElement>(".path-input");
-    const keySelect = row.querySelector<HTMLSelectElement>(".dispatch-key-select");
+  for (const row of document.querySelectorAll<HTMLElement>('#folders-list .list-row')) {
+    const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+    const pathInput = row.querySelector<HTMLInputElement>('.path-input');
+    const keySelect = row.querySelector<HTMLSelectElement>('.dispatch-key-select');
     if (!nameInput || !pathInput || !keySelect) continue;
     const name = nameInput.value.trim();
     const path = pathInput.value.trim();
@@ -36,14 +36,9 @@ export function collectFolders(collected: CollectedConfig): void {
   }
 }
 
-export function addFolderRow(
-  container: HTMLElement,
-  name: string = "",
-  path: string = "",
-  dispatchKey: string = "",
-): void {
-  const row = document.createElement("div");
-  row.className = "list-row";
+export function addFolderRow(container: HTMLElement, name = '', path = '', dispatchKey = ''): void {
+  const row = document.createElement('div');
+  row.className = 'list-row';
   row.innerHTML = `
     <input type="text" class="key-input" placeholder="キー" value="${escapeHtml(name)}">
     <input type="text" class="path-input" placeholder="パス (~/Documents)" value="${escapeHtml(path)}">
@@ -52,26 +47,28 @@ export function addFolderRow(
   `;
   const keySelect = createDispatchKeySelect(dispatchKey);
   row.insertBefore(keySelect, row.firstChild);
-  row.querySelector<HTMLButtonElement>(".btn-remove")?.addEventListener("click", () => row.remove());
-  row.querySelector<HTMLButtonElement>(".btn-browse")?.addEventListener("click", async () => {
+  row
+    .querySelector<HTMLButtonElement>('.btn-remove')
+    ?.addEventListener('click', () => row.remove());
+  row.querySelector<HTMLButtonElement>('.btn-browse')?.addEventListener('click', async () => {
     try {
-      const selected = await invoke<string | null>("browse_folder");
+      const selected = await invoke<string | null>('browse_folder');
       if (selected) {
-        const pathInput = row.querySelector<HTMLInputElement>(".path-input");
+        const pathInput = row.querySelector<HTMLInputElement>('.path-input');
         if (pathInput) pathInput.value = selected;
       }
     } catch (e) {
-      console.error("フォルダ選択に失敗:", e);
+      console.error('フォルダ選択に失敗:', e);
     }
   });
   container.appendChild(row);
 }
 
 export function initFoldersForm(): void {
-  const btn = document.getElementById("btn-add-folder");
-  const list = document.getElementById("folders-list");
+  const btn = document.getElementById('btn-add-folder');
+  const list = document.getElementById('folders-list');
   if (!btn || !list) return;
-  btn.addEventListener("click", () => {
+  btn.addEventListener('click', () => {
     addFolderRow(list);
   });
 }

--- a/muhenkan-switch/frontend/src/forms/general.ts
+++ b/muhenkan-switch/frontend/src/forms/general.ts
@@ -1,7 +1,7 @@
 // ── General tab: autostart / export-import / help / github / open-dir / quit / kanata status / updater ──
-import { invoke, listen, message, ask, shellOpen } from "../lib/tauri";
-import { setConfig } from "../lib/state";
-import type { Config } from "../lib/config";
+import { invoke, listen, message, ask, shellOpen } from '../lib/tauri';
+import { setConfig } from '../lib/state';
+import type { Config } from '../lib/config';
 
 /** Tauri 側 KanataStatus (commands.rs) と対応 */
 interface KanataStatus {
@@ -18,7 +18,7 @@ interface UpdateInfo {
 // ── Kanata status ──
 export async function refreshKanataStatus(): Promise<void> {
   try {
-    const status = await invoke<KanataStatus>("get_kanata_status");
+    const status = await invoke<KanataStatus>('get_kanata_status');
     updateKanataUI(status.running);
   } catch {
     updateKanataUI(false);
@@ -27,40 +27,47 @@ export async function refreshKanataStatus(): Promise<void> {
 
 function updateKanataUI(running: boolean): void {
   // Footer
-  const footerDot = document.getElementById("footer-kanata-dot");
-  const footerText = document.getElementById("footer-kanata-text");
-  if (footerDot) footerDot.classList.toggle("running", running);
-  if (footerText) footerText.textContent = running ? "キー割当: 実行中" : "キー割当: 停止中";
+  const footerDot = document.getElementById('footer-kanata-dot');
+  const footerText = document.getElementById('footer-kanata-text');
+  if (footerDot) footerDot.classList.toggle('running', running);
+  if (footerText) footerText.textContent = running ? 'キー割当: 実行中' : 'キー割当: 停止中';
 }
 
 // ── Autostart checkbox ──
 export async function loadAutostart(): Promise<void> {
-  const autostartCheckbox = document.getElementById("opt-autostart") as HTMLInputElement | null;
+  const autostartCheckbox = document.getElementById('opt-autostart') as HTMLInputElement | null;
   if (!autostartCheckbox) return;
   try {
-    autostartCheckbox.checked = await invoke<boolean>("get_autostart_enabled");
+    autostartCheckbox.checked = await invoke<boolean>('get_autostart_enabled');
   } catch (e) {
-    console.error("自動起動状態の取得に失敗:", e);
+    console.error('自動起動状態の取得に失敗:', e);
   }
 }
 
 // ── Updater ──
-async function checkForUpdate(silent: boolean = true): Promise<void> {
-  let currentVersion = "";
+async function checkForUpdate(silent = true): Promise<void> {
   try {
-    currentVersion = await invoke<string>("get_app_version");
-    const update = await invoke<UpdateInfo | null>("check_update");
+    const currentVersion = await invoke<string>('get_app_version');
+    const update = await invoke<UpdateInfo | null>('check_update');
     if (update) {
-      if (await ask(`現在: v${currentVersion} → 最新: v${update.version}\nアップデートしますか？`, { title: "アップデート" })) {
-        await invoke<void>("stop_kanata");
-        await invoke<void>("install_update");
+      if (
+        await ask(`現在: v${currentVersion} → 最新: v${update.version}\nアップデートしますか？`, {
+          title: 'アップデート',
+        })
+      ) {
+        await invoke('stop_kanata');
+        await invoke('install_update');
       }
     } else if (!silent) {
-      await message(`v${currentVersion} は最新です。`, { title: "アップデート" });
+      await message(`v${currentVersion} は最新です。`, { title: 'アップデート' });
     }
   } catch (e) {
-    console.error("[updater]", e);
-    if (!silent) await message("アップデート確認に失敗しました:\n" + String(e), { title: "エラー", kind: "error" });
+    console.error('[updater]', e);
+    if (!silent)
+      await message('アップデート確認に失敗しました:\n' + String(e), {
+        title: 'エラー',
+        kind: 'error',
+      });
   }
 }
 
@@ -70,72 +77,81 @@ export interface InitGeneralFormOptions {
 
 export function initGeneralForm({ renderConfig }: InitGeneralFormOptions): void {
   // ── Config export / import ──
-  document.getElementById("btn-export-config")?.addEventListener("click", async () => {
+  document.getElementById('btn-export-config')?.addEventListener('click', async () => {
     try {
-      const exported = await invoke<boolean>("export_config");
+      const exported = await invoke<boolean>('export_config');
       if (exported) {
-        await message("設定ファイルをエクスポートしました。", { title: "エクスポート" });
+        await message('設定ファイルをエクスポートしました。', { title: 'エクスポート' });
       }
     } catch (e) {
-      await message("エクスポートに失敗しました:\n" + String(e), { title: "エラー", kind: "error" });
+      await message('エクスポートに失敗しました:\n' + String(e), {
+        title: 'エラー',
+        kind: 'error',
+      });
     }
   });
 
-  document.getElementById("btn-import-config")?.addEventListener("click", async () => {
-    const ok = await ask("現在の設定を上書きします。よろしいですか？", { title: "インポート", kind: "warning" });
+  document.getElementById('btn-import-config')?.addEventListener('click', async () => {
+    const ok = await ask('現在の設定を上書きします。よろしいですか？', {
+      title: 'インポート',
+      kind: 'warning',
+    });
     if (!ok) return;
     try {
-      const newConfig = await invoke<Config | null>("import_config");
+      const newConfig = await invoke<Config | null>('import_config');
       if (newConfig) {
         setConfig(newConfig);
         renderConfig();
-        await message("設定ファイルをインポートしました。", { title: "インポート" });
+        await message('設定ファイルをインポートしました。', { title: 'インポート' });
       }
     } catch (e) {
-      await message("インポートに失敗しました:\n" + String(e), { title: "エラー", kind: "error" });
+      await message('インポートに失敗しました:\n' + String(e), { title: 'エラー', kind: 'error' });
     }
   });
 
   // ── General tab: help / install dir / quit ──
-  document.getElementById("btn-help")?.addEventListener("click", async () => {
+  document.getElementById('btn-help')?.addEventListener('click', async () => {
     try {
-      await invoke<void>("open_help_window");
+      await invoke('open_help_window');
     } catch (e) {
-      console.error("ヘルプウィンドウの表示に失敗:", e);
+      console.error('ヘルプウィンドウの表示に失敗:', e);
     }
   });
 
-  document.getElementById("btn-github")?.addEventListener("click", async () => {
-    await shellOpen("https://github.com/kimushun1101/muhenkan-switch");
+  document.getElementById('btn-github')?.addEventListener('click', async () => {
+    await shellOpen('https://github.com/kimushun1101/muhenkan-switch');
   });
 
-  document.getElementById("btn-open-dir")?.addEventListener("click", async () => {
+  document.getElementById('btn-open-dir')?.addEventListener('click', async () => {
     try {
-      await invoke<void>("open_install_dir");
+      await invoke('open_install_dir');
     } catch (e) {
-      await message("インストール先を開けませんでした:\n" + String(e), { title: "エラー", kind: "error" });
+      await message('インストール先を開けませんでした:\n' + String(e), {
+        title: 'エラー',
+        kind: 'error',
+      });
     }
   });
 
-  document.getElementById("btn-quit")?.addEventListener("click", async () => {
-    await invoke<void>("quit_app");
+  document.getElementById('btn-quit')?.addEventListener('click', async () => {
+    await invoke('quit_app');
   });
 
   // ── Autostart checkbox listener ──
-  const autostartCheckbox = document.getElementById("opt-autostart") as HTMLInputElement | null;
+  const autostartCheckbox = document.getElementById('opt-autostart') as HTMLInputElement | null;
   if (autostartCheckbox) {
-    autostartCheckbox.addEventListener("change", async () => {
+    autostartCheckbox.addEventListener('change', async () => {
       try {
-        await invoke<void>("set_autostart_enabled", { enabled: autostartCheckbox.checked });
+        await invoke('set_autostart_enabled', { enabled: autostartCheckbox.checked });
       } catch (e) {
-        console.error("自動起動の切り替えに失敗:", e);
+        console.error('自動起動の切り替えに失敗:', e);
         autostartCheckbox.checked = !autostartCheckbox.checked;
       }
     });
   }
 
   // ── Kanata status event ──
-  void listen<boolean>("kanata-status-changed", (event) => {
+  void listen<boolean>('kanata-status-changed', (event) => {
     updateKanataUI(event.payload);
   });
 }
@@ -143,12 +159,12 @@ export function initGeneralForm({ renderConfig }: InitGeneralFormOptions): void 
 // ── Updater initialization (called from main init after install type check) ──
 export async function initUpdater(): Promise<void> {
   // インストーラー版のみ自動更新チェック
-  const installType = await invoke<string>("get_install_type");
-  if (installType === "installer") {
+  const installType = await invoke<string>('get_install_type');
+  if (installType === 'installer') {
     // 起動 5 秒後にサイレントチェック
     setTimeout(() => void checkForUpdate(true), 5000);
 
-    // トレイメニューからの手動チェック
-    void listen<void>("check-update-requested", () => void checkForUpdate(false));
+    // トレイメニューからの手動チェック (payload なしイベント)
+    void listen('check-update-requested', () => void checkForUpdate(false));
   }
 }

--- a/muhenkan-switch/frontend/src/forms/search.ts
+++ b/muhenkan-switch/frontend/src/forms/search.ts
@@ -1,29 +1,29 @@
 // ── Search engines form ──
-import { getConfig, getSearchPresets } from "../lib/state";
-import type { SearchPreset } from "../lib/state";
-import { createDispatchKeySelect } from "../lib/dispatch-key";
-import { escapeHtml } from "../lib/utils";
-import type { SearchEntry } from "../lib/config";
-import type { CollectedConfig } from "../lib/config-io";
+import { getConfig, getSearchPresets } from '../lib/state';
+import type { SearchPreset } from '../lib/state';
+import { createDispatchKeySelect } from '../lib/dispatch-key';
+import { escapeHtml } from '../lib/utils';
+import type { SearchEntry } from '../lib/config';
+import type { CollectedConfig } from '../lib/config-io';
 
 export function renderSearchList(): void {
   const config = getConfig();
   if (!config) return;
-  const container = document.getElementById("search-list");
+  const container = document.getElementById('search-list');
   if (!container) return;
-  container.innerHTML = "";
+  container.innerHTML = '';
   for (const [name, entry] of Object.entries(config.search ?? {})) {
-    addSearchRow(container, name, entry.url, entry.key ?? "");
+    addSearchRow(container, name, entry.url, entry.key ?? '');
   }
 }
 
 // Collect search-list rows into the shared collected object.
 // Mirrors the original logic from lib/config-io.ts so behavior is unchanged.
 export function collectSearch(collected: CollectedConfig): void {
-  for (const row of document.querySelectorAll<HTMLElement>("#search-list .list-row")) {
-    const nameInput = row.querySelector<HTMLInputElement>(".key-input");
-    const urlInput = row.querySelector<HTMLInputElement>(".url-input");
-    const keySelect = row.querySelector<HTMLSelectElement>(".dispatch-key-select");
+  for (const row of document.querySelectorAll<HTMLElement>('#search-list .list-row')) {
+    const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+    const urlInput = row.querySelector<HTMLInputElement>('.url-input');
+    const keySelect = row.querySelector<HTMLSelectElement>('.dispatch-key-select');
     if (!nameInput || !urlInput || !keySelect) continue;
     const name = nameInput.value.trim();
     const url = urlInput.value.trim();
@@ -36,14 +36,9 @@ export function collectSearch(collected: CollectedConfig): void {
   }
 }
 
-export function addSearchRow(
-  container: HTMLElement,
-  name: string = "",
-  url: string = "",
-  dispatchKey: string = "",
-): void {
-  const row = document.createElement("div");
-  row.className = "list-row";
+export function addSearchRow(container: HTMLElement, name = '', url = '', dispatchKey = ''): void {
+  const row = document.createElement('div');
+  row.className = 'list-row';
   row.innerHTML = `
     <input type="text" class="key-input" placeholder="機能名" value="${escapeHtml(name)}">
     <input type="text" class="url-input" placeholder="URL テンプレート ({query})" value="${escapeHtml(url)}">
@@ -53,19 +48,19 @@ export function addSearchRow(
   const keySelect = createDispatchKeySelect(dispatchKey);
   row.insertBefore(keySelect, row.firstChild);
 
-  const btnPick = row.querySelector<HTMLButtonElement>(".btn-pick-search");
-  btnPick?.addEventListener("click", async () => {
+  const btnPick = row.querySelector<HTMLButtonElement>('.btn-pick-search');
+  btnPick?.addEventListener('click', async () => {
     const selected = await showSearchPicker();
     if (selected) {
-      const nameInput = row.querySelector<HTMLInputElement>(".key-input");
-      const urlInput = row.querySelector<HTMLInputElement>(".url-input");
+      const nameInput = row.querySelector<HTMLInputElement>('.key-input');
+      const urlInput = row.querySelector<HTMLInputElement>('.url-input');
       if (nameInput) nameInput.value = selected.label;
       if (urlInput) urlInput.value = selected.url;
     }
   });
 
-  const btnRemove = row.querySelector<HTMLButtonElement>(".btn-remove");
-  btnRemove?.addEventListener("click", () => row.remove());
+  const btnRemove = row.querySelector<HTMLButtonElement>('.btn-remove');
+  btnRemove?.addEventListener('click', () => row.remove());
   container.appendChild(row);
 }
 
@@ -73,8 +68,8 @@ export function addSearchRow(
 export function showSearchPicker(): Promise<SearchPreset | null> {
   return new Promise<SearchPreset | null>((resolve) => {
     const SEARCH_PRESETS = getSearchPresets();
-    const overlay = document.createElement("div");
-    overlay.className = "modal-overlay";
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
     overlay.innerHTML = `
       <div class="modal">
         <div class="modal-header">検索サービスを選択</div>
@@ -88,55 +83,57 @@ export function showSearchPicker(): Promise<SearchPreset | null> {
       </div>
     `;
 
-    const list = overlay.querySelector<HTMLUListElement>(".modal-list");
-    const filterInput = overlay.querySelector<HTMLInputElement>(".modal-search");
+    const list = overlay.querySelector<HTMLUListElement>('.modal-list');
+    const filterInput = overlay.querySelector<HTMLInputElement>('.modal-search');
     if (!list || !filterInput) {
       resolve(null);
       return;
     }
 
-    function renderList(filter: string = ""): void {
+    function renderList(filter = ''): void {
       if (!list) return;
-      list.innerHTML = "";
+      list.innerHTML = '';
       const lf = filter.toLowerCase();
       for (const [category, services] of Object.entries(SEARCH_PRESETS)) {
-        const filtered = services.filter((s) =>
-          s.label.toLowerCase().includes(lf) || category.toLowerCase().includes(lf)
+        const filtered = services.filter(
+          (s) => s.label.toLowerCase().includes(lf) || category.toLowerCase().includes(lf),
         );
         if (filtered.length === 0) continue;
-        const header = document.createElement("li");
-        header.className = "modal-list-header";
+        const header = document.createElement('li');
+        header.className = 'modal-list-header';
         header.textContent = category;
         list.appendChild(header);
         for (const svc of filtered) {
-          const li = document.createElement("li");
+          const li = document.createElement('li');
           li.textContent = svc.label;
-          li.addEventListener("click", () => close(svc));
+          li.addEventListener('click', () => close(svc));
           list.appendChild(li);
         }
       }
     }
 
-    filterInput.addEventListener("input", (e) => {
+    filterInput.addEventListener('input', (e) => {
       const target = e.target as HTMLInputElement;
       renderList(target.value);
     });
 
     function close(result: SearchPreset | null): void {
       overlay.remove();
-      document.removeEventListener("keydown", onKeydown);
+      document.removeEventListener('keydown', onKeydown);
       resolve(result);
     }
 
-    overlay.querySelector<HTMLButtonElement>(".btn-cancel")?.addEventListener("click", () => close(null));
-    overlay.addEventListener("click", (e) => {
+    overlay
+      .querySelector<HTMLButtonElement>('.btn-cancel')
+      ?.addEventListener('click', () => close(null));
+    overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close(null);
     });
 
     function onKeydown(e: KeyboardEvent): void {
-      if (e.key === "Escape") close(null);
+      if (e.key === 'Escape') close(null);
     }
-    document.addEventListener("keydown", onKeydown);
+    document.addEventListener('keydown', onKeydown);
 
     renderList();
     document.body.appendChild(overlay);
@@ -145,10 +142,10 @@ export function showSearchPicker(): Promise<SearchPreset | null> {
 }
 
 export function initSearchForm(): void {
-  const btn = document.getElementById("btn-add-search");
-  const list = document.getElementById("search-list");
+  const btn = document.getElementById('btn-add-search');
+  const list = document.getElementById('search-list');
   if (!btn || !list) return;
-  btn.addEventListener("click", () => {
+  btn.addEventListener('click', () => {
     addSearchRow(list);
   });
 }

--- a/muhenkan-switch/frontend/src/forms/timestamp.ts
+++ b/muhenkan-switch/frontend/src/forms/timestamp.ts
@@ -1,7 +1,7 @@
 // ── Timestamp form ──
-import { invoke } from "../lib/tauri";
-import { getConfig } from "../lib/state";
-import type { CollectedConfig } from "../lib/config-io";
+import { invoke } from '../lib/tauri';
+import { getConfig } from '../lib/state';
+import type { CollectedConfig } from '../lib/config-io';
 
 /**
  * 必須 DOM 要素を取得するヘルパー (見つからなければ throw)。
@@ -18,38 +18,38 @@ export function renderTimestamp(): void {
   if (!config) return;
 
   // Format
-  const formatPreset = requireEl<HTMLSelectElement>("ts-format-preset");
-  const formatCustom = requireEl<HTMLInputElement>("ts-format-custom");
+  const formatPreset = requireEl<HTMLSelectElement>('ts-format-preset');
+  const formatCustom = requireEl<HTMLInputElement>('ts-format-custom');
   const format = config.timestamp.format;
 
   const formatOption = Array.from(formatPreset.options).find((o) => o.value === format);
   if (formatOption) {
     formatPreset.value = format;
-    formatCustom.classList.add("hidden");
+    formatCustom.classList.add('hidden');
   } else {
-    formatPreset.value = "custom";
+    formatPreset.value = 'custom';
     formatCustom.value = format;
-    formatCustom.classList.remove("hidden");
+    formatCustom.classList.remove('hidden');
   }
 
   // Delimiter
-  const delimPreset = requireEl<HTMLSelectElement>("ts-delimiter-preset");
-  const delimCustom = requireEl<HTMLInputElement>("ts-delimiter-custom");
-  const delimiter = config.timestamp.delimiter ?? "_";
+  const delimPreset = requireEl<HTMLSelectElement>('ts-delimiter-preset');
+  const delimCustom = requireEl<HTMLInputElement>('ts-delimiter-custom');
+  const delimiter = config.timestamp.delimiter ?? '_';
 
   const delimOption = Array.from(delimPreset.options).find((o) => o.value === delimiter);
   if (delimOption) {
     delimPreset.value = delimiter;
-    delimCustom.classList.add("hidden");
+    delimCustom.classList.add('hidden');
   } else {
-    delimPreset.value = "custom";
+    delimPreset.value = 'custom';
     delimCustom.value = delimiter;
-    delimCustom.classList.remove("hidden");
+    delimCustom.classList.remove('hidden');
   }
 
   // Position
   const posRadio = document.querySelector<HTMLInputElement>(
-    `input[name="ts-position"][value="${config.timestamp.position}"]`
+    `input[name="ts-position"][value="${config.timestamp.position}"]`,
   );
   if (posRadio) posRadio.checked = true;
 
@@ -57,17 +57,17 @@ export function renderTimestamp(): void {
 }
 
 export function getTimestampFormat(): string {
-  const preset = requireEl<HTMLSelectElement>("ts-format-preset").value;
-  if (preset === "custom") {
-    return requireEl<HTMLInputElement>("ts-format-custom").value;
+  const preset = requireEl<HTMLSelectElement>('ts-format-preset').value;
+  if (preset === 'custom') {
+    return requireEl<HTMLInputElement>('ts-format-custom').value;
   }
   return preset;
 }
 
 export function getTimestampDelimiter(): string {
-  const preset = requireEl<HTMLSelectElement>("ts-delimiter-preset").value;
-  if (preset === "custom") {
-    return requireEl<HTMLInputElement>("ts-delimiter-custom").value;
+  const preset = requireEl<HTMLSelectElement>('ts-delimiter-preset').value;
+  if (preset === 'custom') {
+    return requireEl<HTMLInputElement>('ts-delimiter-custom').value;
   }
   return preset;
 }
@@ -78,7 +78,7 @@ export function collectTimestamp(collected: CollectedConfig): void {
   const positionEl = document.querySelector<HTMLInputElement>('input[name="ts-position"]:checked');
   collected.timestamp = {
     format: getTimestampFormat(),
-    position: positionEl?.value ?? "before",
+    position: positionEl?.value ?? 'before',
     delimiter: getTimestampDelimiter(),
   };
 }
@@ -87,52 +87,56 @@ export async function updateTimestampPreview(): Promise<void> {
   const format = getTimestampFormat();
   const delimiter = getTimestampDelimiter();
   const positionEl = document.querySelector<HTMLInputElement>('input[name="ts-position"]:checked');
-  const position = positionEl?.value ?? "before";
-  const previewEl = requireEl<HTMLElement>("ts-preview");
+  const position = positionEl?.value ?? 'before';
+  const previewEl = requireEl<HTMLElement>('ts-preview');
   try {
-    const preview = await invoke<string>("validate_timestamp_format", { format, delimiter, position });
+    const preview = await invoke<string>('validate_timestamp_format', {
+      format,
+      delimiter,
+      position,
+    });
     previewEl.textContent = preview;
-    previewEl.style.color = "";
+    previewEl.style.color = '';
   } catch (e) {
     previewEl.textContent = String(e);
-    previewEl.style.color = "var(--red)";
+    previewEl.style.color = 'var(--red)';
   }
 }
 
 export function initTimestampForm(): void {
-  requireEl<HTMLSelectElement>("ts-format-preset").addEventListener("change", (e) => {
+  requireEl<HTMLSelectElement>('ts-format-preset').addEventListener('change', (e) => {
     const target = e.target as HTMLSelectElement;
-    const customInput = requireEl<HTMLInputElement>("ts-format-custom");
-    if (target.value === "custom") {
-      customInput.classList.remove("hidden");
+    const customInput = requireEl<HTMLInputElement>('ts-format-custom');
+    if (target.value === 'custom') {
+      customInput.classList.remove('hidden');
       customInput.focus();
     } else {
-      customInput.classList.add("hidden");
+      customInput.classList.add('hidden');
     }
     void updateTimestampPreview();
   });
 
-  requireEl<HTMLInputElement>("ts-format-custom").addEventListener("input", () => {
+  requireEl<HTMLInputElement>('ts-format-custom').addEventListener('input', () => {
     void updateTimestampPreview();
   });
 
-  requireEl<HTMLSelectElement>("ts-delimiter-preset").addEventListener("change", (e) => {
+  requireEl<HTMLSelectElement>('ts-delimiter-preset').addEventListener('change', (e) => {
     const target = e.target as HTMLSelectElement;
-    const customInput = requireEl<HTMLInputElement>("ts-delimiter-custom");
-    if (target.value === "custom") {
-      customInput.classList.remove("hidden");
+    const customInput = requireEl<HTMLInputElement>('ts-delimiter-custom');
+    if (target.value === 'custom') {
+      customInput.classList.remove('hidden');
       customInput.focus();
     } else {
-      customInput.classList.add("hidden");
+      customInput.classList.add('hidden');
     }
     void updateTimestampPreview();
   });
 
-  requireEl<HTMLInputElement>("ts-delimiter-custom").addEventListener("input", () => {
+  requireEl<HTMLInputElement>('ts-delimiter-custom').addEventListener('input', () => {
     void updateTimestampPreview();
   });
 
   document.querySelectorAll<HTMLInputElement>('input[name="ts-position"]').forEach((radio) => {
-    radio.addEventListener("change", () => void updateTimestampPreview());
+    radio.addEventListener('change', () => void updateTimestampPreview());
   });
 }

--- a/muhenkan-switch/frontend/src/help.ts
+++ b/muhenkan-switch/frontend/src/help.ts
@@ -4,22 +4,26 @@
 // 共通化のため Tauri API は `lib/tauri.ts` facade 経由で取得する。
 // Phase 3-B で `.ts` 化 (strict)。
 
-import { invoke, listen, getCurrentWindow } from "./lib/tauri";
+import { invoke, listen, getCurrentWindow } from './lib/tauri';
 
 // インストール種別 (installer / script) によって表示を切り替え
-const install = new URLSearchParams(location.search).get("install");
+const install = new URLSearchParams(location.search).get('install');
 if (install) {
-  document.querySelectorAll<HTMLElement>("[data-install]").forEach((el) => {
-    if (el.dataset["install"] !== install) el.style.display = "none";
+  document.querySelectorAll<HTMLElement>('[data-install]').forEach((el) => {
+    if (el.dataset['install'] !== install) el.style.display = 'none';
   });
 }
 
 // キーボード配列 SVG を Tauri 経由で取得して埋め込む
-const container = document.getElementById("keyboard-svg");
-if (!container) {
-  // help.html では必ず存在する想定。strict 化のため明示 fail-fast。
-  throw new Error("Required element #keyboard-svg not found");
+function requireContainer(): HTMLElement {
+  const el = document.getElementById('keyboard-svg');
+  if (!el) {
+    // help.html では必ず存在する想定。strict 化のため明示 fail-fast。
+    throw new Error('Required element #keyboard-svg not found');
+  }
+  return el;
 }
+const container = requireContainer();
 let scale = 1;
 let tx = 0;
 let ty = 0;
@@ -28,58 +32,76 @@ let sx = 0;
 let sy = 0;
 
 function loadSvg(): void {
-  invoke<string>("generate_keyboard_svg").then((svg) => {
-    container!.innerHTML = svg;
-    scale = 1; tx = 0; ty = 0;
-    const svgEl = container!.querySelector<SVGElement>("svg");
-    if (svgEl) svgEl.style.transform = "";
-  }).catch((err: unknown) => {
-    container!.textContent = "キーボード図の読み込みに失敗しました: " + String(err);
-  });
+  invoke<string>('generate_keyboard_svg')
+    .then((svg) => {
+      container.innerHTML = svg;
+      scale = 1;
+      tx = 0;
+      ty = 0;
+      const svgEl = container.querySelector<SVGElement>('svg');
+      if (svgEl) svgEl.style.transform = '';
+    })
+    .catch((err: unknown) => {
+      container.textContent = 'キーボード図の読み込みに失敗しました: ' + String(err);
+    });
 }
 
 function applySvgTransform(): void {
-  const svgEl = container!.querySelector<SVGElement>("svg");
-  if (svgEl) svgEl.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+  const svgEl = container.querySelector<SVGElement>('svg');
+  if (svgEl) svgEl.style.transform = 'translate(' + tx + 'px,' + ty + 'px) scale(' + scale + ')';
 }
 
 // ホイールでズーム（コンテナ上のみ）
-container.addEventListener("wheel", (e: WheelEvent) => {
-  e.preventDefault();
-  const rect = container.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
-  const old = scale;
-  scale = Math.min(5, Math.max(0.5, scale * (e.deltaY < 0 ? 1.12 : 0.88)));
-  const r = scale / old;
-  tx = mx - r * (mx - tx);
-  ty = my - r * (my - ty);
-  applySvgTransform();
-}, { passive: false });
+container.addEventListener(
+  'wheel',
+  (e: WheelEvent) => {
+    e.preventDefault();
+    const rect = container.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const old = scale;
+    scale = Math.min(5, Math.max(0.5, scale * (e.deltaY < 0 ? 1.12 : 0.88)));
+    const r = scale / old;
+    tx = mx - r * (mx - tx);
+    ty = my - r * (my - ty);
+    applySvgTransform();
+  },
+  { passive: false },
+);
 
 // ドラッグで移動
-container.addEventListener("mousedown", (e: MouseEvent) => {
+container.addEventListener('mousedown', (e: MouseEvent) => {
   if (e.button === 0) {
-    dragging = true; sx = e.clientX - tx; sy = e.clientY - ty;
-    container.classList.add("dragging");
+    dragging = true;
+    sx = e.clientX - tx;
+    sy = e.clientY - ty;
+    container.classList.add('dragging');
     e.preventDefault();
   }
 });
-document.addEventListener("mousemove", (e: MouseEvent) => {
-  if (dragging) { tx = e.clientX - sx; ty = e.clientY - sy; applySvgTransform(); }
+document.addEventListener('mousemove', (e: MouseEvent) => {
+  if (dragging) {
+    tx = e.clientX - sx;
+    ty = e.clientY - sy;
+    applySvgTransform();
+  }
 });
-document.addEventListener("mouseup", () => {
-  dragging = false; container.classList.remove("dragging");
+document.addEventListener('mouseup', () => {
+  dragging = false;
+  container.classList.remove('dragging');
 });
 
 // ダブルクリックでリセット
-container.addEventListener("dblclick", () => {
-  scale = 1; tx = 0; ty = 0; applySvgTransform();
+container.addEventListener('dblclick', () => {
+  scale = 1;
+  tx = 0;
+  ty = 0;
+  applySvgTransform();
 });
 
 // Escape → ヘルプウィンドウを閉じる
-document.addEventListener("keydown", (e: KeyboardEvent) => {
-  if (e.key === "Escape") {
+document.addEventListener('keydown', (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
     e.preventDefault();
     void getCurrentWindow().close();
   }
@@ -87,5 +109,7 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
 
 // 初回読み込み
 loadSvg();
-// 設定保存時に自動更新
-void listen<void>("config-saved", () => { loadSvg(); });
+// 設定保存時に自動更新 (payload なしイベント)
+void listen('config-saved', () => {
+  loadSvg();
+});

--- a/muhenkan-switch/frontend/src/lib/config-io.ts
+++ b/muhenkan-switch/frontend/src/lib/config-io.ts
@@ -4,14 +4,11 @@
 // `initConfigIo({ renderers, collectors })` で受け取った関数群へ fan-out する
 // (Issue #140)。Phase 3 TS 化や Phase 4 単体テストでの差し替え/モックを
 // しやすくする目的の純リファクタ。
-import { invoke, message, ask } from "./tauri";
-import type { Config, TimestampConfig } from "./config";
-import {
-  getConfig, setConfig,
-  setAppPresets, setSearchPresets,
-} from "./state";
-import type { AppPresetMap, SearchPresetMap } from "./state";
-import { validateDispatchKeys } from "./dispatch-key";
+import { invoke, message, ask } from './tauri';
+import type { Config, TimestampConfig } from './config';
+import { getConfig, setConfig, setAppPresets, setSearchPresets } from './state';
+import type { AppPresetMap, SearchPresetMap } from './state';
+import { validateDispatchKeys } from './dispatch-key';
 
 /**
  * collectConfig() の途中で組み立てる中間表現。
@@ -33,7 +30,10 @@ export interface InitConfigIoOptions {
 let renderers: Renderer[] = [];
 let collectors: Collector[] = [];
 
-export function initConfigIo({ renderers: r = [], collectors: c = [] }: InitConfigIoOptions = {}): void {
+export function initConfigIo({
+  renderers: r = [],
+  collectors: c = [],
+}: InitConfigIoOptions = {}): void {
   renderers = r;
   collectors = c;
 }
@@ -42,16 +42,16 @@ export function initConfigIo({ renderers: r = [], collectors: c = [] }: InitConf
 export async function loadConfig(): Promise<void> {
   try {
     const [config, appPresets, searchPresets] = await Promise.all([
-      invoke<Config>("get_config"),
-      invoke<AppPresetMap>("get_app_presets"),
-      invoke<SearchPresetMap>("get_search_presets"),
+      invoke<Config>('get_config'),
+      invoke<AppPresetMap>('get_app_presets'),
+      invoke<SearchPresetMap>('get_search_presets'),
     ]);
     setConfig(config);
     setAppPresets(appPresets);
     setSearchPresets(searchPresets);
     renderConfig();
   } catch (e) {
-    console.error("設定の読み込みに失敗:", e);
+    console.error('設定の読み込みに失敗:', e);
   }
 }
 
@@ -61,8 +61,11 @@ export function renderConfig(): void {
   if (!config) return;
 
   // Punctuation style (lib/config-io が直接保持する唯一の DOM 操作)
-  const punc = document.getElementById("punctuation-style") as HTMLInputElement | HTMLSelectElement | null;
-  if (punc) punc.value = config.punctuation_style || "、。";
+  const punc = document.getElementById('punctuation-style') as
+    | HTMLInputElement
+    | HTMLSelectElement
+    | null;
+  if (punc) punc.value = config.punctuation_style || '、。';
 
   // Fan out to per-form renderers (順序は main.ts の初期化順)
   for (const render of renderers) render();
@@ -70,14 +73,17 @@ export function renderConfig(): void {
 
 // ── Collect config from UI ──
 export function collectConfig(): CollectedConfig {
-  const punc = document.getElementById("punctuation-style") as HTMLInputElement | HTMLSelectElement | null;
+  const punc = document.getElementById('punctuation-style') as
+    | HTMLInputElement
+    | HTMLSelectElement
+    | null;
   const collected: CollectedConfig = {
     search: {},
     folders: {},
     apps: {},
     // collectTimestamp が必須フィールドを埋める前提で空オブジェクトで開始
     timestamp: {} as TimestampConfig,
-    punctuation_style: punc?.value || "、。",
+    punctuation_style: punc?.value || '、。',
   };
 
   // Fan out to per-form collectors
@@ -88,53 +94,61 @@ export function collectConfig(): CollectedConfig {
 
 // ── Apply / Reset / Defaults ──
 export function initConfigActions(): void {
-  const btnApply = document.getElementById("btn-apply") as HTMLButtonElement | null;
+  const btnApply = document.getElementById('btn-apply') as HTMLButtonElement | null;
   if (btnApply) {
-    btnApply.addEventListener("click", async () => {
+    btnApply.addEventListener('click', async () => {
       try {
         // Client-side dispatch key validation
         const dupError = validateDispatchKeys();
         if (dupError) {
-          await message(dupError, { title: "エラー", kind: "error" });
+          await message(dupError, { title: 'エラー', kind: 'error' });
           return;
         }
 
         const newConfig = collectConfig();
-        console.log("[apply] saving config:", JSON.stringify(newConfig).slice(0, 200));
-        await invoke<void>("save_config", { config: newConfig });
+        console.log('[apply] saving config:', JSON.stringify(newConfig).slice(0, 200));
+        await invoke('save_config', { config: newConfig });
         setConfig(newConfig);
 
         // Brief save success indicator
         const orig = btnApply.textContent;
-        btnApply.textContent = "保存しました";
-        setTimeout(() => { btnApply.textContent = orig; }, 1500);
+        btnApply.textContent = '保存しました';
+        setTimeout(() => {
+          btnApply.textContent = orig;
+        }, 1500);
       } catch (e) {
-        console.error("[apply] error:", e);
-        await message("保存に失敗しました:\n" + String(e), { title: "エラー", kind: "error" });
+        console.error('[apply] error:', e);
+        await message('保存に失敗しました:\n' + String(e), { title: 'エラー', kind: 'error' });
       }
     });
   }
 
-  const btnReset = document.getElementById("btn-reset") as HTMLButtonElement | null;
+  const btnReset = document.getElementById('btn-reset') as HTMLButtonElement | null;
   if (btnReset) {
-    btnReset.addEventListener("click", async () => {
-      const yes = await ask("未保存の変更を破棄して、最後に保存した設定に戻しますか？", { title: "リセット", kind: "warning" });
+    btnReset.addEventListener('click', async () => {
+      const yes = await ask('未保存の変更を破棄して、最後に保存した設定に戻しますか？', {
+        title: 'リセット',
+        kind: 'warning',
+      });
       if (!yes) return;
       await loadConfig();
     });
   }
 
-  const btnDefaults = document.getElementById("btn-defaults") as HTMLButtonElement | null;
+  const btnDefaults = document.getElementById('btn-defaults') as HTMLButtonElement | null;
   if (btnDefaults) {
-    btnDefaults.addEventListener("click", async () => {
-      const yes = await ask("現在の設定を破棄して、初期値に戻しますか？", { title: "初期値に戻す", kind: "warning" });
+    btnDefaults.addEventListener('click', async () => {
+      const yes = await ask('現在の設定を破棄して、初期値に戻しますか？', {
+        title: '初期値に戻す',
+        kind: 'warning',
+      });
       if (!yes) return;
       try {
-        const next = await invoke<Config>("default_config");
+        const next = await invoke<Config>('default_config');
         setConfig(next);
         renderConfig();
       } catch (e) {
-        console.error("初期値の取得に失敗:", e);
+        console.error('初期値の取得に失敗:', e);
       }
     });
   }

--- a/muhenkan-switch/frontend/src/lib/dispatch-key.ts
+++ b/muhenkan-switch/frontend/src/lib/dispatch-key.ts
@@ -1,31 +1,31 @@
 // ── Dispatch key dropdown helper + duplicate validation ──
 // Search / Folders / Apps の各フォームで共有される。
-import { DISPATCH_KEYS } from "./state";
+import { DISPATCH_KEYS } from './state';
 
-export function createDispatchKeySelect(selectedKey: string = ""): HTMLSelectElement {
-  const select = document.createElement("select");
-  select.className = "dispatch-key-select";
-  select.title = "無変換+キー";
+export function createDispatchKeySelect(selectedKey = ''): HTMLSelectElement {
+  const select = document.createElement('select');
+  select.className = 'dispatch-key-select';
+  select.title = '無変換+キー';
 
-  const noneOpt = document.createElement("option");
-  noneOpt.value = "";
-  noneOpt.textContent = "—";
+  const noneOpt = document.createElement('option');
+  noneOpt.value = '';
+  noneOpt.textContent = '—';
   select.appendChild(noneOpt);
 
   for (const k of DISPATCH_KEYS) {
-    const opt = document.createElement("option");
+    const opt = document.createElement('option');
     opt.value = k;
     opt.textContent = k.toUpperCase();
     select.appendChild(opt);
   }
 
-  select.value = selectedKey || "";
+  select.value = selectedKey || '';
   return select;
 }
 
 export function validateDispatchKeys(): string | null {
   const usedKeys: Record<string, boolean> = {};
-  for (const select of document.querySelectorAll<HTMLSelectElement>(".dispatch-key-select")) {
+  for (const select of document.querySelectorAll<HTMLSelectElement>('.dispatch-key-select')) {
     const key = select.value;
     if (!key) continue;
     if (usedKeys[key]) {

--- a/muhenkan-switch/frontend/src/lib/shortcuts.ts
+++ b/muhenkan-switch/frontend/src/lib/shortcuts.ts
@@ -1,15 +1,15 @@
 // ── Keyboard shortcuts ──
-import { invoke, getCurrentWindow } from "./tauri";
+import { invoke, getCurrentWindow } from './tauri';
 
 export function initShortcuts(): void {
-  document.addEventListener("keydown", (e: KeyboardEvent) => {
+  document.addEventListener('keydown', (e: KeyboardEvent) => {
     // モーダル表示中はショートカット無効（Escapeはモーダル側で処理済み）
-    if (document.querySelector(".modal-overlay")) return;
+    if (document.querySelector('.modal-overlay')) return;
 
     // Ctrl+S → 適用（保存）
-    if (e.ctrlKey && e.key === "s") {
+    if (e.ctrlKey && e.key === 's') {
       e.preventDefault();
-      const btn = document.getElementById("btn-apply") as HTMLButtonElement | null;
+      const btn = document.getElementById('btn-apply') as HTMLButtonElement | null;
       if (btn) {
         btn.focus();
         btn.click();
@@ -18,21 +18,21 @@ export function initShortcuts(): void {
     }
 
     // Ctrl+Q → 終了
-    if (e.ctrlKey && e.key === "q") {
+    if (e.ctrlKey && e.key === 'q') {
       e.preventDefault();
-      void invoke<void>("quit_app");
+      void invoke('quit_app');
       return;
     }
 
     // F1 → ヘルプ
-    if (e.key === "F1") {
+    if (e.key === 'F1') {
       e.preventDefault();
-      void invoke<void>("open_help_window");
+      void invoke('open_help_window');
       return;
     }
 
     // Escape → ウィンドウを隠す（トレイ格納）
-    if (e.key === "Escape") {
+    if (e.key === 'Escape') {
       e.preventDefault();
       void getCurrentWindow().hide();
       return;

--- a/muhenkan-switch/frontend/src/lib/state.ts
+++ b/muhenkan-switch/frontend/src/lib/state.ts
@@ -3,7 +3,7 @@
 // ESM の `let` 直 export は import 側で再代入できないので、
 // getter / setter 関数経由でアクセスする (振る舞いは元コードと同一)。
 
-import type { Config } from "./config";
+import type { Config } from './config';
 
 /** App プリセット 1 件 (config/app-presets.json の各エントリ) */
 export interface AppPreset {
@@ -52,8 +52,21 @@ export function setSearchPresets(next: SearchPresetMap): void {
 
 // ── Available dispatch keys (must match kbd file) ──
 export const DISPATCH_KEYS: readonly string[] = [
-  "1", "2", "3", "4", "5",
-  "q", "w", "e", "r", "t",
-  "a", "s", "d", "f", "g",
-  "z", "b",
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  'q',
+  'w',
+  'e',
+  'r',
+  't',
+  'a',
+  's',
+  'd',
+  'f',
+  'g',
+  'z',
+  'b',
 ];

--- a/muhenkan-switch/frontend/src/lib/tabs.ts
+++ b/muhenkan-switch/frontend/src/lib/tabs.ts
@@ -1,12 +1,12 @@
 // ── Tab switching ──
 export function initTabs(): void {
-  document.querySelectorAll<HTMLElement>(".tab").forEach((tab) => {
-    tab.addEventListener("click", () => {
-      document.querySelectorAll<HTMLElement>(".tab").forEach((t) => t.classList.remove("active"));
-      document.querySelectorAll<HTMLElement>(".panel").forEach((p) => p.classList.remove("active"));
-      tab.classList.add("active");
-      const panel = document.getElementById(`panel-${tab.dataset["tab"] ?? ""}`);
-      if (panel) panel.classList.add("active");
+  document.querySelectorAll<HTMLElement>('.tab').forEach((tab) => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll<HTMLElement>('.tab').forEach((t) => t.classList.remove('active'));
+      document.querySelectorAll<HTMLElement>('.panel').forEach((p) => p.classList.remove('active'));
+      tab.classList.add('active');
+      const panel = document.getElementById(`panel-${tab.dataset['tab'] ?? ''}`);
+      if (panel) panel.classList.add('active');
     });
   });
 }

--- a/muhenkan-switch/frontend/src/lib/tauri.ts
+++ b/muhenkan-switch/frontend/src/lib/tauri.ts
@@ -4,11 +4,11 @@
 // Phase 3-A で `.ts` 化し、`invoke<T>(...)` の戻り値型を呼び出し側で
 // 受け取れる薄い wrapper に発展させる。
 
-import { invoke as tauriInvoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import { open as shellOpen } from "@tauri-apps/plugin-shell";
-import { message, ask } from "@tauri-apps/plugin-dialog";
+import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { open as shellOpen } from '@tauri-apps/plugin-shell';
+import { message, ask } from '@tauri-apps/plugin-dialog';
 
 /**
  * Tauri コマンドを呼び出す型付きファサード。

--- a/muhenkan-switch/frontend/src/lib/utils.ts
+++ b/muhenkan-switch/frontend/src/lib/utils.ts
@@ -1,4 +1,8 @@
 // ── Utility ──
 export function escapeHtml(str: string): string {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }

--- a/muhenkan-switch/frontend/src/main.ts
+++ b/muhenkan-switch/frontend/src/main.ts
@@ -3,27 +3,15 @@
 // `@tauri-apps/api` 採用 + Tauri グローバル直叩きは廃止済み、`withGlobalTauri: false`)。
 // Phase 3-B で全 .js を .ts 化し strict 設定で typecheck を pass させた。
 
-import { invoke } from "./lib/tauri";
-import { initTabs } from "./lib/tabs";
-import { initShortcuts } from "./lib/shortcuts";
-import {
-  loadConfig, renderConfig, initConfigActions, initConfigIo,
-} from "./lib/config-io";
-import {
-  initTimestampForm, renderTimestamp, collectTimestamp,
-} from "./forms/timestamp";
-import {
-  initSearchForm, renderSearchList, collectSearch,
-} from "./forms/search";
-import {
-  initFoldersForm, renderFoldersList, collectFolders,
-} from "./forms/folders";
-import {
-  initAppsForm, renderAppsList, collectApps,
-} from "./forms/apps";
-import {
-  initGeneralForm, refreshKanataStatus, loadAutostart, initUpdater,
-} from "./forms/general";
+import { invoke } from './lib/tauri';
+import { initTabs } from './lib/tabs';
+import { initShortcuts } from './lib/shortcuts';
+import { loadConfig, renderConfig, initConfigActions, initConfigIo } from './lib/config-io';
+import { initTimestampForm, renderTimestamp, collectTimestamp } from './forms/timestamp';
+import { initSearchForm, renderSearchList, collectSearch } from './forms/search';
+import { initFoldersForm, renderFoldersList, collectFolders } from './forms/folders';
+import { initAppsForm, renderAppsList, collectApps } from './forms/apps';
+import { initGeneralForm, refreshKanataStatus, loadAutostart, initUpdater } from './forms/general';
 
 // ── Initialize ──
 async function init(): Promise<void> {
@@ -49,11 +37,11 @@ async function init(): Promise<void> {
 
   // フッターにバージョン表示
   try {
-    const version = await invoke<string>("get_app_version");
-    const footerVersion = document.getElementById("footer-version");
-    if (footerVersion) footerVersion.textContent = "v" + version;
+    const version = await invoke<string>('get_app_version');
+    const footerVersion = document.getElementById('footer-version');
+    if (footerVersion) footerVersion.textContent = 'v' + version;
   } catch (e) {
-    console.error("バージョン情報の取得に失敗:", e);
+    console.error('バージョン情報の取得に失敗:', e);
   }
 
   // インストーラー版のみ自動更新チェック

--- a/muhenkan-switch/frontend/styles/main.css
+++ b/muhenkan-switch/frontend/styles/main.css
@@ -1,5 +1,7 @@
 /* ── Reset & Base ── */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -19,8 +21,8 @@
   --yellow: #f9e2af;
   --border: #45475a;
   --radius: 6px;
-  --font: "Segoe UI", system-ui, -apple-system, sans-serif;
-  --font-mono: "Cascadia Code", "Consolas", monospace;
+  --font: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Cascadia Code', 'Consolas', monospace;
 }
 
 body {
@@ -121,7 +123,7 @@ legend {
   letter-spacing: 0.5px;
 }
 
-input[type="text"],
+input[type='text'],
 select {
   width: 100%;
   padding: 7px 10px;
@@ -135,12 +137,12 @@ select {
   transition: border-color 0.15s;
 }
 
-input[type="text"]:focus,
+input[type='text']:focus,
 select:focus {
   border-color: var(--accent);
 }
 
-input[type="text"][readonly] {
+input[type='text'][readonly] {
   opacity: 0.7;
   cursor: default;
 }
@@ -249,7 +251,7 @@ button:disabled {
   align-items: center;
 }
 
-.list-row input[type="text"] {
+.list-row input[type='text'] {
   flex: 1;
 }
 


### PR DESCRIPTION
## 概要

Phase 4-B として ESLint v10 + typescript-eslint v8 + Prettier v3 を導入し、CI で lint / format check を強制する。

## 変更内容

- `frontend/package.json`: devDependencies (eslint, @eslint/js, typescript-eslint, eslint-config-prettier, prettier, globals) + scripts (lint / lint:fix / format / format:check) 追加
- `frontend/eslint.config.js`: flat config 新規作成 (`tseslint.configs.strict` + `stylistic`、typed lint なし、`eslint-config-prettier/flat` を最後に配置)
- `frontend/.prettierrc.json` + `frontend/.prettierignore`: Prettier 設定新規作成
- `.github/workflows/ci.yml`: frontend-check job に lint / format:check step を追加 (typecheck と build の間)
- `frontend/src/**/*.ts` ほか: ESLint --fix と Prettier --write による自動整形、および strict ルール対応の手動 fix
- `frontend/help.html` / `frontend/index.html` / `frontend/styles/main.css`: Prettier による HTML / CSS 整形
- `.gitattributes`: Prettier 整形対象 (.ts/.js/.json/.html/.css) に `eol=lf` を明示 (Windows checkout 時の CRLF 変換による format:check 失敗を防止)

## 設定方針 (Researcher 確定)

- typed lint (parserOptions.projectService) は採用せず — `tsc --noEmit` で十分カバー、lint 時間 2-5 倍化のデメリット回避
- eslint-plugin-prettier は採用せず — `format` 別コマンドが現代の主流
- CI は同 job 内 step として追加 — 別 job 化すると npm ci 重複でセットアップコストが嵩む

## 受け入れ基準

- [x] `npm run lint` pass (violation 0)
- [x] `npm run format:check` pass
- [x] `npm run typecheck` 影響なし
- [x] `npm run build` 影響なし
- [ ] CI green (Linux / Windows / macOS) — PR 作成後に確認

## 決定事項

- **`@eslint/js` のバージョン指定**: Researcher 指定の `^10.3.0` は npm registry に存在せず (eslint 本体のみ 10.3.0 まで release、`@eslint/js` は 10.0.1 が最新)。`^10.0.0` に下げて対応 (機能差なし、ESLint v10 系の同梱推奨ペアリング)。
- **strict ルール由来の手動 fix (合計 17 件)**:
  - `no-async-promise-executor` (apps.ts × 1): `new Promise(async (resolve) => {...})` を、async 部分を Promise の前に出して解消。
  - `no-useless-assignment` (general.ts × 1): `let currentVersion = ""` の初期化を try ブロック内 `const` 宣言に変更。
  - `@typescript-eslint/no-invalid-void-type` (general.ts × 6 / config-io.ts × 1 / shortcuts.ts × 2 / help.ts × 1): `invoke<void>(...)` / `listen<void>(...)` の `<void>` を削除 (戻り値捨て、または payload なしイベント)。**型契約の意味的変化を許容**: `<void>` は「値が無いことを宣言」する意図だったが、`@typescript-eslint/no-invalid-void-type` の意図 (generic 引数に void を渡すべきでない) と衝突。Tauri 公式 typing では `invoke<T>` は戻り値型として T を扱うため、`<unknown>` 化に伴う「Rust 側仕様変更時の検出力低下」を許容する判断。`lib/tauri.ts` への `invokeVoid` facade 追加は別 issue で検討余地あり。
  - `@typescript-eslint/no-non-null-assertion` (help.ts × 4): `container!` を `requireContainer()` ヘルパー関数による narrowing に書き換え。fail-fast 性質は保持。
- **disable コメント**: 未使用 (0 件)。
- **ESLint `ignores` glob**: `dist/**` / `node_modules/**` / `**/*.config.js` に強化 (Reviewer 推奨-2 対応、サブディレクトリの設定ファイルもカバー)。
- **`no-floating-promises` 不発の認識共有**: Issue #156 本文の「必須ルール: ... no-floating-promises 等」のうち、本ルールは type-aware であり、本 PR では typed lint を不採用としたため有効化されない。typed lint のパフォーマンスデメリット (lint 時間 2-5 倍化) を避ける優先順位の判断。Phase 4-C (Vitest) 以降で必要に応じて typed lint 化を再検討。
- **ESLint v10 採用に伴う IDE 拡張への影響**: ESLint v10 はエコシステム全体としては比較的新しいメジャー。VSCode 等の ESLint 拡張は概ね対応済みだが、ローカル環境で警告が出る場合は拡張バージョンの更新を推奨。

## 備考

- AGENTS.md / CLAUDE.md の「Vanilla JS」記述更新は **Phase 4-D で対応予定** (本 PR scope 外)。
- `requireContainer()` (help.ts) と `requireEl<T>()` (forms/timestamp.ts) の `lib/dom-utils.ts` 集約は別 issue で検討。

Closes #156