### PR TITLE
docs: AGENTS.md / design.md / development.md を Phase 4 後の現状に更新 (#159)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — muhenkan-switch
 
 3-crate Cargo workspace + Tauri v2 GUI + kanata プロセス管理。
-詳細構成は `Cargo.toml` 参照。フロントエンドは `muhenkan-switch/frontend/` (Vanilla JS + Vite。`frontend/package.json` で依存管理、`mise run build` で自動ビルドされる)。
+詳細構成は `Cargo.toml` 参照。フロントエンドは `muhenkan-switch/frontend/` (TypeScript strict + Vite + Vitest)。`mise run build` 内で `npm ci` + `vite build` まで自動実行される。
 
 ## マルチプラットフォーム (Win / Linux / macOS)
 
@@ -18,9 +18,29 @@
 
 ## コーディング規約
 
-- **エラー型**: `anyhow::Result<T>`。独自エラー型は作らない。致命的は `bail!()`、外部ツール (wmctrl/xdotool/notify-send 等) の失敗は `eprintln!` で警告して続行
-- **テスト命名**: `test_{対象}_{条件}` または `{関数名}_{シナリオ}`
+- **エラー型 (Rust)**: `anyhow::Result<T>`。独自エラー型は作らない。致命的は `bail!()`、外部ツール (wmctrl/xdotool/notify-send 等) の失敗は `eprintln!` で警告して続行
+- **テスト命名 (Rust)**: `test_{対象}_{条件}` または `{関数名}_{シナリオ}`
 - **言語**: UI 日本語 / コードコメント英語可 / コミット日本語
+- **フロントエンド**: スタイル・lint 規約は `muhenkan-switch/frontend/eslint.config.js` と `.prettierrc` が single source of truth。AGENTS.md には書かず、`npm run lint` / `npm run format:check` で検証する
+
+## フロントエンド (TypeScript + Vite + Vitest)
+
+`muhenkan-switch/frontend/` 配下で実行。CI (PR トリガー) で typecheck / lint / format:check / test / build を全 OS で強制している。
+
+```bash
+cd muhenkan-switch/frontend
+npm run typecheck     # tsc --noEmit
+npm run lint          # eslint .
+npm run format:check  # prettier --check .
+npm run test          # vitest run
+npm run build         # vite build (mise run build からも呼ばれる)
+```
+
+- **テスト配置**: `src/{lib,forms}/__tests__/` 集約 (co-locate しない)
+- **vitest 設定**: `vitest.config.ts` を独立配置 (vite.config.js には統合しない)
+- **DOM env**: happy-dom (jsdom より軽量。足りない API に当たったら jsdom 切替を検討)
+- **vitest globals**: `false`。各テストで `import { describe, expect, it } from 'vitest'` を明示
+- **改行コード**: Prettier `endOfLine: 'lf'` のため `.gitattributes` で対象拡張子を `eol=lf` 指定済 (Windows checkout 時の CRLF で format:check が落ちるのを回避)
 
 ## ブランチ・PR 運用
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,11 @@
 - **エラー型 (Rust)**: `anyhow::Result<T>`。独自エラー型は作らない。致命的は `bail!()`、外部ツール (wmctrl/xdotool/notify-send 等) の失敗は `eprintln!` で警告して続行
 - **テスト命名 (Rust)**: `test_{対象}_{条件}` または `{関数名}_{シナリオ}`
 - **言語**: UI 日本語 / コードコメント英語可 / コミット日本語
-- **フロントエンド**: スタイル・lint 規約は `muhenkan-switch/frontend/eslint.config.js` と `.prettierrc` が single source of truth。AGENTS.md には書かず、`npm run lint` / `npm run format:check` で検証する
+- **フロントエンド**: スタイル・lint 規約は `muhenkan-switch/frontend/eslint.config.js` と `.prettierrc.json` が single source of truth。AGENTS.md には書かず、`npm run lint` / `npm run format:check` で検証する
 
 ## フロントエンド (TypeScript + Vite + Vitest)
 
-`muhenkan-switch/frontend/` 配下で実行。CI (PR トリガー) で typecheck / lint / format:check / test / build を全 OS で強制している。
+`muhenkan-switch/frontend/` 配下で実行。CI で typecheck / lint / format:check / test / build を全 OS で強制している。
 
 ```bash
 cd muhenkan-switch/frontend
@@ -40,7 +40,7 @@ npm run build         # vite build (mise run build からも呼ばれる)
 - **vitest 設定**: `vitest.config.ts` を独立配置 (vite.config.js には統合しない)
 - **DOM env**: happy-dom (jsdom より軽量。足りない API に当たったら jsdom 切替を検討)
 - **vitest globals**: `false`。各テストで `import { describe, expect, it } from 'vitest'` を明示
-- **改行コード**: Prettier `endOfLine: 'lf'` のため `.gitattributes` で対象拡張子を `eol=lf` 指定済 (Windows checkout 時の CRLF で format:check が落ちるのを回避)
+- **改行コード**: Prettier `endOfLine: 'lf'` (`.prettierrc.json`) のため `.gitattributes` で対象拡張子を `eol=lf` 指定済 (Windows checkout 時の CRLF で format:check が落ちるのを回避)
 
 ## ブランチ・PR 運用
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,7 +14,7 @@
 - kanata を外部バイナリとして利用（クレート組み込みはしない）
 - kanata と muhenkan-switch は `cmd` アクション（プロセス起動）で疎結合に接続
 - muhenkan-switch は非同期なし・ライフタイム注釈なしのシンプルな Rust コード（Windows の Win32 API 呼び出しのみ unsafe を使用）
-- GUI は Tauri v2 + Vanilla JS + Vite（Node.js LTS が必要、`mise run build` で frontend/dist を自動生成）で設定の閲覧・編集を提供
+- GUI は Tauri v2 + TypeScript (strict) + Vite + Vitest（Node.js LTS が必要、`mise run build` で frontend/dist を自動生成）で設定の閲覧・編集を提供
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,7 @@ HMR を使った高速開発をする場合は `cd muhenkan-switch && npx --yes 
 
 ### フロントエンド開発タスク
 
-`muhenkan-switch/frontend/` 配下で以下のタスクが利用できる。CI (PR トリガー) では typecheck / lint / format:check / test / build を全 OS で強制している。
+`muhenkan-switch/frontend/` 配下で以下のタスクが利用できる。CI では typecheck / lint / format:check / test / build を全 OS で強制している。
 
 ```bash
 cd muhenkan-switch/frontend
@@ -75,7 +75,7 @@ npm run test:coverage # vitest run --coverage
 npm run build         # vite build (mise run build からも呼ばれる)
 ```
 
-スタイル・lint 規約の詳細は `eslint.config.js` と `.prettierrc` を single source of truth として参照。
+スタイル・lint 規約の詳細は `eslint.config.js` と `.prettierrc.json` を single source of truth として参照。
 
 ## Windows でビルド・実行がブロックされる場合
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,7 @@
 
 - [Rust ツールチェーン](https://rustup.rs/)
 - [mise](https://mise.jdx.dev/)（タスクランナーとして使用）
+- Node.js LTS（フロントエンド (Tauri webview) のビルドに必要。`mise.toml` で自動セットアップされる）
 
 ```bash
 # Rust のインストール
@@ -56,6 +57,25 @@ mise run test       # ユニットテスト
 ```
 
 HMR を使った高速開発をする場合は `cd muhenkan-switch && npx --yes @tauri-apps/cli@2 dev --config tauri.conf.dev.json` を使用してください。
+
+### フロントエンド開発タスク
+
+`muhenkan-switch/frontend/` 配下で以下のタスクが利用できる。CI (PR トリガー) では typecheck / lint / format:check / test / build を全 OS で強制している。
+
+```bash
+cd muhenkan-switch/frontend
+npm run typecheck     # tsc --noEmit (TypeScript strict)
+npm run lint          # eslint .
+npm run lint:fix      # eslint . --fix
+npm run format        # prettier --write .
+npm run format:check  # prettier --check .
+npm run test          # vitest run
+npm run test:watch    # vitest (watch mode)
+npm run test:coverage # vitest run --coverage
+npm run build         # vite build (mise run build からも呼ばれる)
+```
+
+スタイル・lint 規約の詳細は `eslint.config.js` と `.prettierrc` を single source of truth として参照。
 
 ## Windows でビルド・実行がブロックされる場合
 
@@ -194,6 +214,28 @@ cargo test --workspace
 - テスト名: `test_{カテゴリ}_{何を検証するか}` または `{関数名}_{条件}_{期待結果}`
 - 場所: 各 `.rs` ファイル内 `#[cfg(test)] mod tests`
 - ファイル I/O を伴うテストは `std::env::temp_dir()` を使用し、末尾で cleanup
+
+### フロントエンド自動テスト（Vitest）
+
+```
+cd muhenkan-switch/frontend
+npm run test            # vitest run
+npm run test:coverage   # vitest run --coverage (coverage/ に出力)
+```
+
+#### テストの場所
+
+`src/{lib,forms}/__tests__/*.test.ts` に集約配置（co-locate しない）。
+
+- `src/lib/__tests__/utils.test.ts` — ユーティリティ関数
+- `src/lib/__tests__/dispatch-key.test.ts` — ディスパッチキー解決
+- `src/forms/__tests__/timestamp.test.ts` — timestamp フォームの collect
+
+#### 規約
+
+- テスト DOM: happy-dom（`vitest.config.ts` で `environment: 'happy-dom'`）
+- vitest globals は `false`。各テストで `import { describe, expect, it } from 'vitest'` を明示
+- Tauri `invoke` を呼ぶモジュールは `vi.mock('../lib/tauri')` で差し替える
 
 ### 手動テスト（Ubuntu 22.04 X11）
 

--- a/muhenkan-switch/frontend/vite.config.js
+++ b/muhenkan-switch/frontend/vite.config.js
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 
 const host = process.env.TAURI_DEV_HOST;
 
-// Vite config for Tauri v2 (Phase 1: Vanilla JS, no @tauri-apps/api yet)
+// Vite config for Tauri v2 (TypeScript strict + @tauri-apps/api 経由)
 // See: https://v2.tauri.app/start/frontend/vite/
 export default defineConfig({
   // Tauri 環境で相対パス解決するため (defensive)


### PR DESCRIPTION
## 概要

Phase 4-A〜C 完了後の現状に合わせて、フロントエンド技術スタック・ビルド/テスト/lint タスク・テスト方針を AGENTS.md / docs に反映する Phase 4-D。これで Phase 4 親 (#151) も閉じる。

## 変更点

### `AGENTS.md` (= `CLAUDE.md` symlink)

- 冒頭の技術スタック記述を `Vanilla JS + Vite` → `TypeScript strict + Vite + Vitest` に更新
- 「コーディング規約」を Rust / フロントエンドで分離し、フロントエンドのスタイル・lint 規約は `eslint.config.js` と `.prettierrc` を **single source of truth** として参照する旨を明記 (issue 受け入れ基準: AGENTS.md にスタイル規約をハードコードしない)
- 新セクション「フロントエンド (TypeScript + Vite + Vitest)」を追加:
  - 開発タスク (`npm run typecheck` / `lint` / `format:check` / `test` / `build`) と CI 強制
  - Phase 4-C で確定したテスト方針 (配置 `src/{lib,forms}/__tests__/`、`vitest.config.ts` 独立、`globals: false`、DOM env happy-dom)
  - `.gitattributes` の `eol=lf` 注意書き

### `docs/design.md`

- GUI 行 `Tauri v2 + Vanilla JS + Vite` → `Tauri v2 + TypeScript (strict) + Vite + Vitest` に更新

### `docs/development.md`

- 前提条件に Node.js LTS (mise が自動セットアップ) を追記
- 「フロントエンド開発タスク」セクションを追加 (npm scripts 一覧 + SSoT 参照)
- 「フロントエンド自動テスト (Vitest)」セクションを追加 (場所・規約・Tauri invoke モック方法)

## 検証

- `cd muhenkan-switch/frontend && npm run format:check` — All files use Prettier code style
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test` — 21 passed (3 test files)

## 受け入れ基準 (#159)

- [x] AGENTS.md と CLAUDE.md (リポルート) の Vanilla JS 記述が現状を反映
- [x] AGENTS.md にスタイル規約のハードコードが残っていない (ESLint/Prettier 設定への参照に置換)
- [x] README.md / docs/ にも矛盾記述がないこと (README.md は技術スタック記述なし、docs/design.md と docs/development.md を更新)
- [ ] PR レビューで疎漏がないことを確認 ← レビュアー判定

## 親 issue への影響

- #159 をクローズすると Phase 4 親 #151 のサブタスクが全て完了するため、#151 もクローズ可能になる
- Phase 4 全体: 4-A (#152/PR #153) ・ 4-B (#156/PR #157) ・ 4-C (#158/PR #161) ・ 4-D (本 PR) で完了

Closes #159