### PR TITLE
refactor(frontend): DOM ヘルパー (requireEl) を lib/dom-utils.ts に集約 (#160)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/timestamp.ts
+++ b/muhenkan-switch/frontend/src/forms/timestamp.ts
@@ -2,16 +2,7 @@
 import { invoke } from '../lib/tauri';
 import { getConfig } from '../lib/state';
 import type { CollectedConfig } from '../lib/config-io';
-
-/**
- * 必須 DOM 要素を取得するヘルパー (見つからなければ throw)。
- * 元 .js では non-null 前提で書かれていたので strict 化後も例外で fail-fast する。
- */
-function requireEl<T extends HTMLElement>(id: string): T {
-  const el = document.getElementById(id) as T | null;
-  if (!el) throw new Error(`Required element #${id} not found`);
-  return el;
-}
+import { requireEl } from '../lib/dom-utils';
 
 export function renderTimestamp(): void {
   const config = getConfig();

--- a/muhenkan-switch/frontend/src/help.ts
+++ b/muhenkan-switch/frontend/src/help.ts
@@ -5,6 +5,7 @@
 // Phase 3-B で `.ts` 化 (strict)。
 
 import { invoke, listen, getCurrentWindow } from './lib/tauri';
+import { requireEl } from './lib/dom-utils';
 
 // インストール種別 (installer / script) によって表示を切り替え
 const install = new URLSearchParams(location.search).get('install');
@@ -15,15 +16,7 @@ if (install) {
 }
 
 // キーボード配列 SVG を Tauri 経由で取得して埋め込む
-function requireContainer(): HTMLElement {
-  const el = document.getElementById('keyboard-svg');
-  if (!el) {
-    // help.html では必ず存在する想定。strict 化のため明示 fail-fast。
-    throw new Error('Required element #keyboard-svg not found');
-  }
-  return el;
-}
-const container = requireContainer();
+const container = requireEl<HTMLElement>('keyboard-svg');
 let scale = 1;
 let tx = 0;
 let ty = 0;

--- a/muhenkan-switch/frontend/src/lib/dom-utils.ts
+++ b/muhenkan-switch/frontend/src/lib/dom-utils.ts
@@ -1,0 +1,13 @@
+// ── DOM helpers ──
+// strict 化後、`document.getElementById` の `null` 戻りを fail-fast に変換する共通ヘルパー。
+// 個別ファイルで再定義していた `requireContainer` / `requireEl` を本モジュールに集約する。
+
+/**
+ * 必須 DOM 要素を取得する。見つからなければ throw。
+ * 元 .js では non-null 前提で書かれていたので strict 化後も例外で fail-fast する。
+ */
+export function requireEl<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id) as T | null;
+  if (!el) throw new Error(`Required element #${id} not found`);
+  return el;
+}


### PR DESCRIPTION
## 概要

- `src/lib/dom-utils.ts` を新規追加し `requireEl<T>()` を集約
- `help.ts` のローカル `requireContainer()` を削除、`requireEl<HTMLElement>('keyboard-svg')` に置換
- `forms/timestamp.ts` のローカル `requireEl()` を削除、`lib/dom-utils.ts` から import
- ヘルパー定義箇所は 1 箇所のみに集約 (機能差分なし)

## 由来

PR #157 (Phase 4-B) Reviewer 指摘 (任意改善-2)。`@typescript-eslint/no-non-null-assertion` 対応で fail-fast 取得ヘルパーが 2 箇所に並存していたため。

## 受け入れ基準

- [x] `npm run typecheck` pass
- [x] `npm run lint` pass
- [x] `npm run format:check` pass
- [x] `npm run test` pass (21/21 — utils 7 / dispatch-key 8 / timestamp 6)
- [x] `npm run build` pass
- [x] DOM ヘルパー定義箇所が 1 箇所のみ
- [x] 機能差分なし (UI 動作・エラー時挙動が同等)

Closes #160