### PR TITLE
test(frontend): Phase 4-C 派生 — timestamp / dispatch-key カバー追加 (#162)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/__tests__/timestamp.test.ts
+++ b/muhenkan-switch/frontend/src/forms/__tests__/timestamp.test.ts
@@ -2,10 +2,25 @@
 //
 // collectTimestamp は invoke を経由する preview 更新を含まないため、
 // Tauri バックエンドのモック無しでも純粋に DOM だけで検証できる。
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { collectTimestamp, getTimestampDelimiter, getTimestampFormat } from '../timestamp';
+// renderTimestamp / initTimestampForm / updateTimestampPreview は
+// `../lib/tauri` の `invoke` を経由するので vi.mock で差し替える。
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import {
+  collectTimestamp,
+  getTimestampDelimiter,
+  getTimestampFormat,
+  initTimestampForm,
+  renderTimestamp,
+  updateTimestampPreview,
+} from '../timestamp';
+import { invoke } from '../../lib/tauri';
+import { setConfig } from '../../lib/state';
+import type { Config, TimestampConfig } from '../../lib/config';
 import type { CollectedConfig } from '../../lib/config-io';
-import type { TimestampConfig } from '../../lib/config';
+
+vi.mock('../../lib/tauri', () => ({
+  invoke: vi.fn(),
+}));
 
 function setupTimestampDom(): void {
   document.body.innerHTML = `
@@ -24,6 +39,7 @@ function setupTimestampDom(): void {
     <input id="ts-delimiter-custom" type="text" value="" />
     <input type="radio" name="ts-position" value="before" />
     <input type="radio" name="ts-position" value="after" />
+    <span id="ts-preview"></span>
   `;
 }
 
@@ -37,8 +53,23 @@ function emptyCollected(): CollectedConfig {
   };
 }
 
+function makeConfig(timestamp: TimestampConfig): Config {
+  return {
+    search: {},
+    folders: {},
+    apps: {},
+    timestamp,
+    punctuation_style: '、。',
+  };
+}
+
 beforeEach(() => {
   setupTimestampDom();
+  (invoke as unknown as Mock).mockReset();
+  // renderTimestamp の末尾 (`void updateTimestampPreview()`) で invoke が呼ばれるため、
+  // 既定値を返さないと unhandled rejection 警告が出る。個別テストで mockResolvedValueOnce
+  // / mockRejectedValueOnce で上書きする想定。
+  (invoke as unknown as Mock).mockResolvedValue('preview-default');
 });
 
 afterEach(() => {
@@ -104,5 +135,224 @@ describe('collectTimestamp', () => {
     collectTimestamp(collected);
 
     expect(collected.timestamp.position).toBe('before');
+  });
+
+  it('propagates the custom delimiter input value via the "custom" preset path', () => {
+    // delimiter preset='custom' + custom input='+' の組合せが
+    // collected.timestamp.delimiter まで素通しで伝播することを確認 (Issue #162)。
+    (document.getElementById('ts-format-preset') as HTMLSelectElement).value = '%Y%m%d';
+    (document.getElementById('ts-delimiter-preset') as HTMLSelectElement).value = 'custom';
+    (document.getElementById('ts-delimiter-custom') as HTMLInputElement).value = '+';
+
+    const collected = emptyCollected();
+    collectTimestamp(collected);
+
+    expect(collected.timestamp.delimiter).toBe('+');
+  });
+});
+
+describe('renderTimestamp', () => {
+  it('reflects a preset-matched format / delimiter and hides custom inputs', () => {
+    setConfig(
+      makeConfig({
+        format: '%Y-%m-%d',
+        position: 'after',
+        delimiter: '-',
+      }),
+    );
+
+    renderTimestamp();
+
+    const formatPreset = document.getElementById('ts-format-preset') as HTMLSelectElement;
+    const formatCustom = document.getElementById('ts-format-custom') as HTMLInputElement;
+    const delimPreset = document.getElementById('ts-delimiter-preset') as HTMLSelectElement;
+    const delimCustom = document.getElementById('ts-delimiter-custom') as HTMLInputElement;
+
+    expect(formatPreset.value).toBe('%Y-%m-%d');
+    expect(formatCustom.classList.contains('hidden')).toBe(true);
+    expect(delimPreset.value).toBe('-');
+    expect(delimCustom.classList.contains('hidden')).toBe(true);
+
+    const afterRadio = document.querySelector<HTMLInputElement>(
+      'input[name="ts-position"][value="after"]',
+    );
+    expect(afterRadio?.checked).toBe(true);
+  });
+
+  it('switches to "custom" and reveals custom inputs when format / delimiter are not in presets', () => {
+    setConfig(
+      makeConfig({
+        format: '%Y/%m/%d',
+        position: 'before',
+        delimiter: '+',
+      }),
+    );
+
+    renderTimestamp();
+
+    const formatPreset = document.getElementById('ts-format-preset') as HTMLSelectElement;
+    const formatCustom = document.getElementById('ts-format-custom') as HTMLInputElement;
+    const delimPreset = document.getElementById('ts-delimiter-preset') as HTMLSelectElement;
+    const delimCustom = document.getElementById('ts-delimiter-custom') as HTMLInputElement;
+
+    expect(formatPreset.value).toBe('custom');
+    expect(formatCustom.value).toBe('%Y/%m/%d');
+    expect(formatCustom.classList.contains('hidden')).toBe(false);
+
+    expect(delimPreset.value).toBe('custom');
+    expect(delimCustom.value).toBe('+');
+    expect(delimCustom.classList.contains('hidden')).toBe(false);
+
+    const beforeRadio = document.querySelector<HTMLInputElement>(
+      'input[name="ts-position"][value="before"]',
+    );
+    expect(beforeRadio?.checked).toBe(true);
+  });
+
+  it('treats a null/undefined delimiter as the default "_" preset', () => {
+    setConfig(
+      makeConfig({
+        format: '%Y%m%d',
+        position: 'before',
+        // 通常 Rust 側 (default_delimiter() が "_" を返す) で補完されるため undefined は
+        // 来ないが、フロント側 defensive fallback (`?? '_'`) を pin するため強制注入する。
+        delimiter: undefined as unknown as string,
+      }),
+    );
+
+    renderTimestamp();
+
+    const delimPreset = document.getElementById('ts-delimiter-preset') as HTMLSelectElement;
+    const delimCustom = document.getElementById('ts-delimiter-custom') as HTMLInputElement;
+    expect(delimPreset.value).toBe('_');
+    expect(delimCustom.classList.contains('hidden')).toBe(true);
+  });
+
+  it('returns early without throwing when no config is set', () => {
+    // setConfig は型上 Config 必須だが、初期状態 (config==null) の早期 return 分岐
+    // (timestamp.ts:9 `if (!config) return;`) を pin するため type cast で null を注入する。
+    // state.ts に testability API (resetConfig 等) を追加して cast を解消する追跡 issue: #165
+    setConfig(null as unknown as Config);
+    expect(() => renderTimestamp()).not.toThrow();
+  });
+});
+
+describe('updateTimestampPreview', () => {
+  it('writes the invoke result into #ts-preview and clears the color on success', async () => {
+    (invoke as unknown as Mock).mockResolvedValueOnce('20251231');
+    (document.getElementById('ts-format-preset') as HTMLSelectElement).value = '%Y%m%d';
+    (document.getElementById('ts-delimiter-preset') as HTMLSelectElement).value = '_';
+
+    const previewEl = document.getElementById('ts-preview') as HTMLElement;
+    previewEl.style.color = 'var(--red)'; // 前回のエラー残骸を再現
+    await updateTimestampPreview();
+
+    expect(previewEl.textContent).toBe('20251231');
+    expect(previewEl.style.color).toBe('');
+    expect(invoke).toHaveBeenCalledWith('validate_timestamp_format', {
+      format: '%Y%m%d',
+      delimiter: '_',
+      position: 'before',
+    });
+  });
+
+  it('writes the error string and a red color when invoke rejects', async () => {
+    (invoke as unknown as Mock).mockRejectedValueOnce(new Error('bad format'));
+    (document.getElementById('ts-format-preset') as HTMLSelectElement).value = '%Y%m%d';
+    (document.getElementById('ts-delimiter-preset') as HTMLSelectElement).value = '_';
+
+    const previewEl = document.getElementById('ts-preview') as HTMLElement;
+    await updateTimestampPreview();
+
+    expect(previewEl.textContent).toBe('Error: bad format');
+    expect(previewEl.style.color).toBe('var(--red)');
+  });
+});
+
+describe('initTimestampForm', () => {
+  it('reveals format-custom on "custom" change and hides it for other presets', () => {
+    initTimestampForm();
+    const formatPreset = document.getElementById('ts-format-preset') as HTMLSelectElement;
+    const formatCustom = document.getElementById('ts-format-custom') as HTMLInputElement;
+
+    formatPreset.value = 'custom';
+    formatPreset.dispatchEvent(new Event('change'));
+    expect(formatCustom.classList.contains('hidden')).toBe(false);
+
+    formatPreset.value = '%Y%m%d';
+    formatPreset.dispatchEvent(new Event('change'));
+    expect(formatCustom.classList.contains('hidden')).toBe(true);
+  });
+
+  it('reveals delimiter-custom on "custom" change and hides it for other presets', () => {
+    initTimestampForm();
+    const delimPreset = document.getElementById('ts-delimiter-preset') as HTMLSelectElement;
+    const delimCustom = document.getElementById('ts-delimiter-custom') as HTMLInputElement;
+
+    delimPreset.value = 'custom';
+    delimPreset.dispatchEvent(new Event('change'));
+    expect(delimCustom.classList.contains('hidden')).toBe(false);
+
+    delimPreset.value = '_';
+    delimPreset.dispatchEvent(new Event('change'));
+    expect(delimCustom.classList.contains('hidden')).toBe(true);
+  });
+
+  it('triggers a preview update when format-custom receives input', () => {
+    initTimestampForm();
+    (invoke as unknown as Mock).mockClear();
+    (invoke as unknown as Mock).mockResolvedValue('preview-format-custom');
+
+    // format は preset='custom' のときだけ custom input が読まれる
+    // (実コード getTimestampFormat 参照)。両方を準備した上で input 発火。
+    const formatPreset = document.getElementById('ts-format-preset') as HTMLSelectElement;
+    formatPreset.value = 'custom';
+    const formatCustom = document.getElementById('ts-format-custom') as HTMLInputElement;
+    formatCustom.value = '%Y/%m/%d';
+    formatCustom.dispatchEvent(new Event('input'));
+
+    // updateTimestampPreview の冒頭は同期で `invoke(...)` まで進むため
+    // microtask flush なしでも呼び出し自体は assert 可能。
+    expect(invoke).toHaveBeenCalledWith(
+      'validate_timestamp_format',
+      expect.objectContaining({ format: '%Y/%m/%d' }),
+    );
+  });
+
+  it('triggers a preview update when delimiter-custom receives input', () => {
+    initTimestampForm();
+    (invoke as unknown as Mock).mockClear();
+    (invoke as unknown as Mock).mockResolvedValue('preview-delim-custom');
+
+    // delimiter は preset='custom' のときだけ custom input が読まれるので
+    // 両方を準備した上で input イベントを発火させる。
+    const delimPreset = document.getElementById('ts-delimiter-preset') as HTMLSelectElement;
+    delimPreset.value = 'custom';
+    const delimCustom = document.getElementById('ts-delimiter-custom') as HTMLInputElement;
+    delimCustom.value = '+';
+    delimCustom.dispatchEvent(new Event('input'));
+
+    expect(invoke).toHaveBeenCalledWith(
+      'validate_timestamp_format',
+      expect.objectContaining({ delimiter: '+' }),
+    );
+  });
+
+  it('triggers a preview update when a position radio changes', () => {
+    initTimestampForm();
+    (invoke as unknown as Mock).mockClear();
+    (invoke as unknown as Mock).mockResolvedValue('preview-position');
+
+    const afterRadio = document.querySelector<HTMLInputElement>(
+      'input[name="ts-position"][value="after"]',
+    );
+    if (!afterRadio) throw new Error('after radio not found');
+    afterRadio.checked = true;
+    afterRadio.dispatchEvent(new Event('change'));
+
+    expect(invoke).toHaveBeenCalledWith(
+      'validate_timestamp_format',
+      expect.objectContaining({ position: 'after' }),
+    );
   });
 });

--- a/muhenkan-switch/frontend/src/lib/__tests__/dispatch-key.test.ts
+++ b/muhenkan-switch/frontend/src/lib/__tests__/dispatch-key.test.ts
@@ -33,6 +33,14 @@ describe('createDispatchKeySelect', () => {
     const select = createDispatchKeySelect();
     expect(select.value).toBe('');
   });
+
+  it('falls back to empty value when the preselect key is not in DISPATCH_KEYS', () => {
+    // WHATWG HTML 仕様 (HTMLSelectElement.value setter) により、マッチする option が
+    // 無い value をセットすると selectedIndex=-1 となり、value getter は空文字を返す
+    // (= 最初の '—' option ではなく "選択なし")。happy-dom も同仕様に従うことを pin する。
+    const select = createDispatchKeySelect('qqqqqqq');
+    expect(select.value).toBe('');
+  });
 });
 
 describe('validateDispatchKeys', () => {


### PR DESCRIPTION
## Summary
- Phase 4-C 派生 (#162) — frontend テストカバー追加。本体ソース無変更、純粋テスト追加 PR
- timestamp.ts: render / init / preview 系 + collectTimestamp delimiter custom (合計 11 ケース)
- dispatch-key.ts: DISPATCH_KEYS 外 preselect key の fallback 1 ケース

## Coverage (vitest --coverage / v8 provider)
- `timestamp.ts`: **26.5% → 100%** (stmts / branches / funcs / lines)
- `dispatch-key.ts`: 100% 維持
- 受け入れ基準 (60%+) を達成

## ローカル検証
| コマンド | 結果 |
|---|---|
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run test` | pass (3 files / 34 tests) |
| `npm run build` | pass |

## Reviewer subagent 指摘の反映 (4 段階分類)
- **blocker**: 0
- **強く推奨 2 件** → 全て反映
  - S-1 (`delimiter: undefined` テストのコメントを Rust 側挙動と整合する文言に修正、`default_delimiter()=="_"` を実装で確認済)
  - S-2 (`setConfig(null as unknown as Config)` の type cast: 追跡 issue #165 を起票してコメントに pin、本 PR では cast 維持)
- **任意改善 3 件反映**: N-1 (microtask flush 削除して同期 assert 化)、N-2 (beforeEach mock 既定値の意図コメント追加)、N-4 (dispatch-key コメントを WHATWG HTML 仕様の文言に修正)

## Follow-up (本 PR scope 外)
- #165: `state.ts` に testability API (`resetConfig` 等) を追加し、本 PR の type cast を解消
- 別 issue 候補: `vi.mocked()` 統一 (本 PR の `(invoke as unknown as Mock)` 二段キャスト 12 箇所を整理)
- 別 issue 候補: `vitest.config.ts` に coverage 閾値を導入し CI で強制 (本 PR で 100% 化したファイルのデグレ防止)

## Test plan
- [x] CI 全 OS green を確認
- [x] timestamp.ts カバレッジが 60%+ に達する
- [x] dispatch-key.ts カバレッジが 100% を維持
- [x] 既存 21 ケース + 追加 13 ケースで合計 34 ケース pass

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)