### PR TITLE
test(frontend): state.ts に resetConfig() を追加し type cast を解消 (#165)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/__tests__/timestamp.test.ts
+++ b/muhenkan-switch/frontend/src/forms/__tests__/timestamp.test.ts
@@ -14,7 +14,7 @@ import {
   updateTimestampPreview,
 } from '../timestamp';
 import { invoke } from '../../lib/tauri';
-import { setConfig } from '../../lib/state';
+import { resetConfig, setConfig } from '../../lib/state';
 import type { Config, TimestampConfig } from '../../lib/config';
 import type { CollectedConfig } from '../../lib/config-io';
 
@@ -229,10 +229,9 @@ describe('renderTimestamp', () => {
   });
 
   it('returns early without throwing when no config is set', () => {
-    // setConfig は型上 Config 必須だが、初期状態 (config==null) の早期 return 分岐
-    // (timestamp.ts:9 `if (!config) return;`) を pin するため type cast で null を注入する。
-    // state.ts に testability API (resetConfig 等) を追加して cast を解消する追跡 issue: #165
-    setConfig(null as unknown as Config);
+    // 初期状態 (config==null) の早期 return 分岐 (timestamp.ts:9 `if (!config) return;`)
+    // を pin する。`setConfig` は型上 Config 必須なので testability 用 `resetConfig` で戻す。
+    resetConfig();
     expect(() => renderTimestamp()).not.toThrow();
   });
 });

--- a/muhenkan-switch/frontend/src/lib/state.ts
+++ b/muhenkan-switch/frontend/src/lib/state.ts
@@ -34,6 +34,12 @@ export function setConfig(next: Config): void {
   config = next;
 }
 
+// テスト専用: 初期状態 (config==null) の早期 return 分岐を pin するため、
+// `setConfig(null as unknown as Config)` で API 契約を破らずに状態を戻すための API。
+export function resetConfig(): void {
+  config = null;
+}
+
 export function getAppPresets(): AppPresetMap {
   return APP_PRESETS;
 }


### PR DESCRIPTION
## Summary

- `state.ts` に testability 用 API `resetConfig()` を追加 (内部 `config` を `null` に戻す)
- `timestamp.test.ts` の `setConfig(null as unknown as Config)` を `resetConfig()` に置換し、`setConfig` の型契約 (`Config` 必須) 破壊を解消
- 将来 `setConfig` に non-null assertion / バリデーションを追加しても壊れない構造に

## 変更ファイル

- `muhenkan-switch/frontend/src/lib/state.ts` — `resetConfig()` 追加 (+6 行)
- `muhenkan-switch/frontend/src/forms/__tests__/timestamp.test.ts` — type cast 解消 + import 追加 + コメント更新 (+4 / -5)

## ローカル CI (worktree, Linux)

```
typecheck: ✓
lint:      ✓
format:    All matched files use Prettier code style!
test:      34/34 passed (timestamp.test.ts 18 ケース全 pass)
build:     ✓ (174ms)
```

## Test plan

- [ ] CI (Linux / Windows / macOS) 全 OS green
- [ ] timestamp.test.ts の `'returns early without throwing when no config is set'` ケースが pass

## 派生元

PR #166 (Issue #162 Phase 4-C) Reviewer 指摘 S-2 を独立 issue 化 → 本 PR で消化。

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)