### PR TITLE
test(frontend): vitest.config.ts に coverage 閾値を追加し CI で強制 (#167)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,13 @@ cd muhenkan-switch/frontend
 npm run typecheck     # tsc --noEmit
 npm run lint          # eslint .
 npm run format:check  # prettier --check .
-npm run test          # vitest run
+npm run test          # vitest run --coverage (coverage 閾値 per-file 80% を強制)
 npm run build         # vite build (mise run build からも呼ばれる)
 ```
 
 - **テスト配置**: `src/{lib,forms}/__tests__/` 集約 (co-locate しない)
 - **vitest 設定**: `vitest.config.ts` を独立配置 (vite.config.js には統合しない)
+- **coverage 閾値**: `vitest.config.ts` の `coverage.include` を **テスト済ファイルだけ whitelist**、各ファイルに per-file 80% (lines/functions/branches/statements) を強制。新規テスト追加時は include に対象ファイルを足す
 - **DOM env**: happy-dom (jsdom より軽量。足りない API に当たったら jsdom 切替を検討)
 - **vitest globals**: `false`。各テストで `import { describe, expect, it } from 'vitest'` を明示
 - **改行コード**: Prettier `endOfLine: 'lf'` (`.prettierrc.json`) のため `.gitattributes` で対象拡張子を `eol=lf` 指定済 (Windows checkout 時の CRLF で format:check が落ちるのを回避)

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,9 +69,8 @@ npm run lint          # eslint .
 npm run lint:fix      # eslint . --fix
 npm run format        # prettier --write .
 npm run format:check  # prettier --check .
-npm run test          # vitest run
-npm run test:watch    # vitest (watch mode)
-npm run test:coverage # vitest run --coverage
+npm run test          # vitest run --coverage (per-file 80% 閾値強制)
+npm run test:watch    # vitest (watch mode、coverage なし)
 npm run build         # vite build (mise run build からも呼ばれる)
 ```
 
@@ -219,8 +218,7 @@ cargo test --workspace
 
 ```
 cd muhenkan-switch/frontend
-npm run test            # vitest run
-npm run test:coverage   # vitest run --coverage (coverage/ に出力)
+npm run test            # vitest run --coverage (coverage/ に HTML 出力 + 閾値判定)
 ```
 
 #### テストの場所
@@ -236,6 +234,7 @@ npm run test:coverage   # vitest run --coverage (coverage/ に出力)
 - テスト DOM: happy-dom（`vitest.config.ts` で `environment: 'happy-dom'`）
 - vitest globals は `false`。各テストで `import { describe, expect, it } from 'vitest'` を明示
 - Tauri `invoke` を呼ぶモジュールは `vi.mock('../lib/tauri')` で差し替える
+- coverage 閾値は `vitest.config.ts` の `coverage.include` で whitelist 化したファイルにのみ per-file 80% を強制（lines/functions/branches/statements）。新規テスト追加時は include に対象ファイルを足す
 
 ### 手動テスト（Ubuntu 22.04 X11）
 

--- a/muhenkan-switch/frontend/package.json
+++ b/muhenkan-switch/frontend/package.json
@@ -12,9 +12,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tauri-apps/api": "~2.10.1",

--- a/muhenkan-switch/frontend/vitest.config.ts
+++ b/muhenkan-switch/frontend/vitest.config.ts
@@ -1,4 +1,4 @@
-// Vitest config (Phase 4-C, Issue #158)
+// Vitest config (Phase 4-C, Issue #158 — coverage 閾値追加 Issue #167)
 //
 // vite.config.js が `.js` のままなので test フィールドを混ぜず独立 config にする。
 // vite 5.4 との互換性確保のため vitest 2.x 系を採用。
@@ -15,8 +15,18 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['src/**/*.ts'],
+      // include は **テスト済ファイル** だけを whitelist。新しいテストを追加した
+      // 時は対象ファイルをここに足す。未テストファイルを混ぜず、cover 済の品質
+      // 維持を per-file 閾値で強制する設計 (Issue #167)。
+      include: ['src/lib/utils.ts', 'src/lib/dispatch-key.ts', 'src/forms/timestamp.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/__tests__/**'],
+      thresholds: {
+        perFile: true,
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- `coverage.include` を **テスト済ファイル whitelist** (`utils.ts` / `dispatch-key.ts` / `timestamp.ts`) + `thresholds.perFile: true` で **各ファイルに lines/functions/branches/statements 80%** を強制
- `npm run test` を `vitest run --coverage` に変更し、ローカル/CI 共通で閾値判定が走るようにする (`test:coverage` script は冗長になるため削除)
- AGENTS.md / docs/development.md に閾値方針を 1 bullet 追記

## 設計判断

issue #167 検討事項のうち、推奨方針 (per-file 閾値 + include を whitelist 化) を採用:

- **(a) グローバル閾値 1 つ** → 効果薄
- **(b) per-file 閾値 (全ファイル)** → 未テスト多数で fail
- **(c) per-file + include whitelist** ← **採用**

新規テスト追加時は include に対象ファイルを足す運用 (PR 単位で着実にカバー対象を伸ばす)。

## 変更ファイル

- `muhenkan-switch/frontend/vitest.config.ts` — include whitelist + thresholds 追加 (+12 / -2)
- `muhenkan-switch/frontend/package.json` — `test` を `--coverage` 化、`test:coverage` 削除 (+2 / -3)
- `AGENTS.md` — 閾値方針 1 bullet 追記 (+1 / -1)
- `docs/development.md` — 閾値方針 1 bullet 追記 (+5 / -5)

新規依存追加なし (`@vitest/coverage-v8` は既存の devDependency)。`package-lock.json` 変更なし。

## ローカル CI (worktree, Linux)

```
typecheck:    ✓
lint:         ✓
format:check: All matched files use Prettier code style!
test:         34/34 passed, coverage 100% (3 files), exit 0
build:        ✓ (215ms)
```

### 閾値割れ verify

`include` に未カバーの `src/main.ts` を一時追加 → `npm run test` exit **1** で fail することを確認 → 元に戻して exit 0 を再確認:

```
ERROR: Coverage for lines (0%) does not meet global threshold (80%) for src/main.ts
ERROR: Coverage for functions (0%) does not meet global threshold (80%) for src/main.ts
ERROR: Coverage for statements (0%) does not meet global threshold (80%) for src/main.ts
ERROR: Coverage for branches (0%) does not meet global threshold (80%) for src/main.ts
===EXIT: 1===
```

## Test plan

- [ ] CI (Linux / Windows / macOS) 全 OS green
- [ ] frontend-check ジョブ内 `npm run test` で coverage 取得 + per-file 80% 閾値判定が走る
- [ ] テスト 34 ケース全 pass を維持

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)