### PR TITLE
refactor(frontend): IPC 型を lib/ipc-types.ts に集約 (#176)

### DIFF
--- a/muhenkan-switch/frontend/src/forms/apps.ts
+++ b/muhenkan-switch/frontend/src/forms/apps.ts
@@ -5,12 +5,7 @@ import { createDispatchKeySelect } from '../lib/dispatch-key';
 import { escapeHtml } from '../lib/utils';
 import type { AppEntry } from '../lib/config';
 import type { CollectedConfig } from '../lib/config-io';
-
-/** Tauri 側 ProcessInfo (commands.rs) と対応 */
-interface ProcessInfo {
-  name: string;
-  pid: number;
-}
+import type { ProcessInfo } from '../lib/ipc-types';
 
 // ── App select dropdown helper ──
 export function createAppSelect(currentProcess = '', currentCommand = ''): HTMLSelectElement {

--- a/muhenkan-switch/frontend/src/forms/general.ts
+++ b/muhenkan-switch/frontend/src/forms/general.ts
@@ -2,18 +2,7 @@
 import { invoke, listen, message, ask, shellOpen } from '../lib/tauri';
 import { setConfig } from '../lib/state';
 import type { Config } from '../lib/config';
-
-/** Tauri 側 KanataStatus (commands.rs) と対応 */
-interface KanataStatus {
-  running: boolean;
-  pid: number | null;
-}
-
-/** Tauri 側 UpdateInfo (commands.rs) と対応 */
-interface UpdateInfo {
-  version: string;
-  body: string | null;
-}
+import type { KanataStatus, UpdateInfo } from '../lib/ipc-types';
 
 // ── Kanata status ──
 export async function refreshKanataStatus(): Promise<void> {

--- a/muhenkan-switch/frontend/src/lib/ipc-types.ts
+++ b/muhenkan-switch/frontend/src/lib/ipc-types.ts
@@ -1,0 +1,21 @@
+// Tauri command の引数/戻り値型 (IPC 型)。
+// Rust 側 `muhenkan-switch/src/commands.rs` の対応 struct と手動同期する。
+// ts-rs は Tauri command シグネチャを生成できないため、tauri-specta v2 stable 化までは手作業集約で運用 (Issue #135 / #176)。
+
+/** Tauri 側 `KanataStatus` (commands.rs) と対応 */
+export interface KanataStatus {
+  running: boolean;
+  pid: number | null;
+}
+
+/** Tauri 側 `UpdateInfo` (commands.rs) と対応 */
+export interface UpdateInfo {
+  version: string;
+  body: string | null;
+}
+
+/** Tauri 側 `ProcessInfo` (commands.rs) と対応 */
+export interface ProcessInfo {
+  name: string;
+  pid: number;
+}


### PR DESCRIPTION
## 変更内容

Tauri command の引数/戻り値型 (IPC 型) を `frontend/src/lib/ipc-types.ts` に集約。

- **新規**: `lib/ipc-types.ts` — 3 interface (`KanataStatus` / `UpdateInfo` / `ProcessInfo`) + 運用コメント
- **修正**: `forms/general.ts` / `forms/apps.ts` — interface 定義削除、`import type` に置換

ts-rs (#172/#173) は Tauri command シグネチャを生成できないため、tauri-specta v2 stable 化までは手作業集約で運用する旨を `ipc-types.ts` 冒頭コメントに明記。

## 動作確認

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` 通過 (34 tests, 100% coverage)
- [x] `npm run build` 通過
- [x] CI green (Linux / Windows / macOS)

## 軽量 PR 判定 (lessons.md L201 (2))

機能差分なし / 3 ファイル (新規 1 + 修正 2) / 設定無変更 / Rust 側無変更 / 純リファクタ
→ Reviewer subagent スキップ、CI green 確認のみで merge 予定。

Closes #176
Refs #135