### PR TITLE
refactor(config): punctuation_style を Rust 側 enum PunctuationStyle 化

### DIFF
--- a/muhenkan-switch-config/src/lib.rs
+++ b/muhenkan-switch-config/src/lib.rs
@@ -117,13 +117,40 @@ pub struct Config {
     #[serde(default)]
     pub timestamp: TimestampConfig,
     /// 句読点スタイル。kanata の kbd ファイルに反映される。
-    #[serde(default = "default_punctuation_style")]
-    #[ts(type = "\"、。\" | \"，．\" | \"，。\" | \"、．\"")]
-    pub punctuation_style: String,
+    #[serde(default)]
+    pub punctuation_style: PunctuationStyle,
 }
 
-fn default_punctuation_style() -> String {
-    "、。".to_string()
+/// 句読点スタイル。kanata の kbd ファイルに反映される 4 種類。
+/// TOML / JSON 上は `"、。"` のような文字列リテラルで表現される。
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default, TS)]
+#[ts(export, export_to = "config.ts")]
+pub enum PunctuationStyle {
+    /// 「、」「。」（デフォルト）
+    #[serde(rename = "、。")]
+    #[default]
+    TenMaru,
+    /// 「，」「．」
+    #[serde(rename = "，．")]
+    CommaPeriod,
+    /// 「，」「。」
+    #[serde(rename = "，。")]
+    CommaMaru,
+    /// 「、」「．」
+    #[serde(rename = "、．")]
+    TenPeriod,
+}
+
+impl PunctuationStyle {
+    /// kbd ファイル等で使う文字列表現（TOML / TS 上のリテラル値と一致）。
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PunctuationStyle::TenMaru => "、。",
+            PunctuationStyle::CommaPeriod => "，．",
+            PunctuationStyle::CommaMaru => "，。",
+            PunctuationStyle::TenPeriod => "、．",
+        }
+    }
 }
 
 impl Config {
@@ -274,7 +301,7 @@ pub fn default_config() -> Config {
         folders: IndexMap::new(),
         apps: IndexMap::new(),
         timestamp: TimestampConfig::default(),
-        punctuation_style: default_punctuation_style(),
+        punctuation_style: PunctuationStyle::default(),
     }
 }
 
@@ -382,7 +409,7 @@ pub fn save(path: &std::path::Path, config: &Config) -> Result<()> {
     }
 
     // punctuation_style（トップレベル）
-    doc["punctuation_style"] = toml_edit::value(&config.punctuation_style);
+    doc["punctuation_style"] = toml_edit::value(config.punctuation_style.as_str());
 
     // [timestamp] セクション
     let ts_table = doc
@@ -432,13 +459,7 @@ pub fn validate(config: &Config) -> Vec<String> {
         ));
     }
 
-    // punctuation_style の検証
-    if !["、。", "，．", "，。", "、．"].contains(&config.punctuation_style.as_str()) {
-        errors.push(format!(
-            "punctuation_style は \"、。\", \"，．\", \"，。\", \"、．\" のいずれかを指定してください (現在: \"{}\")",
-            config.punctuation_style
-        ));
-    }
+    // punctuation_style は enum で型ガード済（serde が無効値を deserialize 段階で reject）。
 
     // search URL テンプレートの検証
     for (name, entry) in &config.search {
@@ -498,7 +519,10 @@ pub fn validate(config: &Config) -> Vec<String> {
 // ── kbd punctuation rewrite ──
 
 /// kbd ファイル内の句読点行を指定スタイルに書き換える。
-pub fn rewrite_kbd_punctuation(kbd_path: &std::path::Path, style: &str) -> Result<()> {
+pub fn rewrite_kbd_punctuation(
+    kbd_path: &std::path::Path,
+    style: &PunctuationStyle,
+) -> Result<()> {
     let content = std::fs::read_to_string(kbd_path)
         .with_context(|| format!("kbd ファイルの読み込みに失敗しました: {}", kbd_path.display()))?;
 
@@ -509,10 +533,10 @@ pub fn rewrite_kbd_punctuation(kbd_path: &std::path::Path, style: &str) -> Resul
         "(unicode 、)  (unicode ．)",
     ];
     let new_fragment = match style {
-        "，．" => "(unicode ，)  (unicode ．)",
-        "，。" => "(unicode ，)  (unicode 。)",
-        "、．" => "(unicode 、)  (unicode ．)",
-        _ => "(unicode 、)  (unicode 。)",
+        PunctuationStyle::TenMaru => "(unicode 、)  (unicode 。)",
+        PunctuationStyle::CommaPeriod => "(unicode ，)  (unicode ．)",
+        PunctuationStyle::CommaMaru => "(unicode ，)  (unicode 。)",
+        PunctuationStyle::TenPeriod => "(unicode 、)  (unicode ．)",
     };
 
     let mut new_content = content.clone();
@@ -792,7 +816,7 @@ mod tests {
             folders: IndexMap::new(),
             apps: IndexMap::new(),
             timestamp: TimestampConfig::default(),
-            punctuation_style: default_punctuation_style(),
+            punctuation_style: PunctuationStyle::default(),
         };
         // Assign all 15 dispatch keys across sections
         let keys = DISPATCH_KEYS;
@@ -967,6 +991,46 @@ mod tests {
         let result = get_folder_path(&folders, "nonexistent");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nonexistent"));
+    }
+
+    // ── F. PunctuationStyle (enum 化に伴うシリアライズ確認) ──
+
+    #[test]
+    fn test_punctuation_style_serde_all_variants() {
+        // TOML 文字列リテラル ⇄ enum の双方向変換を全 4 variant で確認
+        let cases = [
+            ("、。", PunctuationStyle::TenMaru),
+            ("，．", PunctuationStyle::CommaPeriod),
+            ("，。", PunctuationStyle::CommaMaru),
+            ("、．", PunctuationStyle::TenPeriod),
+        ];
+        for (literal, expected) in cases {
+            let toml_str = format!("punctuation_style = \"{}\"\n", literal);
+            let config: Config = toml::from_str(&toml_str).unwrap();
+            assert_eq!(config.punctuation_style, expected, "deserialize: {}", literal);
+            let dumped = toml::to_string(&config).unwrap();
+            assert!(
+                dumped.contains(&format!("punctuation_style = \"{}\"", literal)),
+                "serialize round-trip should keep literal {}: actual = {}",
+                literal,
+                dumped
+            );
+        }
+    }
+
+    #[test]
+    fn test_punctuation_style_default_when_missing() {
+        // punctuation_style が省略された TOML はデフォルト値 (「、。」) を採用
+        let config: Config = toml::from_str("[search]\n").unwrap();
+        assert_eq!(config.punctuation_style, PunctuationStyle::TenMaru);
+    }
+
+    #[test]
+    fn test_punctuation_style_invalid_rejected() {
+        // 4 variant 以外の文字列は deserialize 時点で reject される（型ガード）
+        let toml_str = "punctuation_style = \"invalid\"\n";
+        let result: Result<Config, _> = toml::from_str(toml_str);
+        assert!(result.is_err(), "invalid punctuation_style should fail to parse");
     }
 
     #[test]

--- a/muhenkan-switch-config/src/svg.rs
+++ b/muhenkan-switch-config/src/svg.rs
@@ -1,4 +1,4 @@
-use crate::Config;
+use crate::{Config, PunctuationStyle};
 
 /// キーの物理配置を定義する構造体。
 struct KeyDef {
@@ -28,7 +28,7 @@ enum KeyCategory {
 
 /// 右手キーの固定機能名。
 /// 右手キーの固定機能名（kanata/muhenkan.kbd の mh-layer 定義に準拠）。
-fn text_edit_label(key: &str, punctuation_style: &str) -> &'static str {
+fn text_edit_label(key: &str, punctuation_style: &PunctuationStyle) -> &'static str {
     match key {
         // hjkl: Vim 風カーソル移動
         "H" => "←",
@@ -46,12 +46,12 @@ fn text_edit_label(key: &str, punctuation_style: &str) -> &'static str {
         ";" => "Esc",
         // ,.: 句読点（4パターン対応）
         "," => match punctuation_style {
-            "，．" | "，。" => "全角，",
-            _ => "、",
+            PunctuationStyle::CommaPeriod | PunctuationStyle::CommaMaru => "全角，",
+            PunctuationStyle::TenMaru | PunctuationStyle::TenPeriod => "、",
         },
         "." => match punctuation_style {
-            "，．" | "、．" => "全角．",
-            _ => "。",
+            PunctuationStyle::CommaPeriod | PunctuationStyle::TenPeriod => "全角．",
+            PunctuationStyle::TenMaru | PunctuationStyle::CommaMaru => "。",
         },
         _ => "",
     }

--- a/muhenkan-switch-core/src/commands/open_folder.rs
+++ b/muhenkan-switch-core/src/commands/open_folder.rs
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn run_missing_folder_errors() {
         let config = Config {
-            punctuation_style: "、。".to_string(),
+            punctuation_style: Default::default(),
             search: Default::default(),
             folders: Default::default(),
             apps: Default::default(),
@@ -105,7 +105,7 @@ mod tests {
             },
         );
         let config = Config {
-            punctuation_style: "、。".to_string(),
+            punctuation_style: Default::default(),
             search: Default::default(),
             folders,
             apps: Default::default(),
@@ -129,7 +129,7 @@ mod tests {
             },
         );
         let config = Config {
-            punctuation_style: "、。".to_string(),
+            punctuation_style: Default::default(),
             search: Default::default(),
             folders,
             apps: Default::default(),

--- a/muhenkan-switch-core/src/commands/switch_app.rs
+++ b/muhenkan-switch-core/src/commands/switch_app.rs
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn run_missing_app_errors() {
         let config = Config {
-            punctuation_style: "、。".to_string(),
+            punctuation_style: Default::default(),
             search: Default::default(),
             folders: Default::default(),
             apps: Default::default(),

--- a/muhenkan-switch/frontend/src/lib/config-io.ts
+++ b/muhenkan-switch/frontend/src/lib/config-io.ts
@@ -83,8 +83,7 @@ export function collectConfig(): CollectedConfig {
     apps: {},
     // collectTimestamp が必須フィールドを埋める前提で空オブジェクトで開始
     timestamp: {} as TimestampConfig,
-    // ts-rs で literal union に強化された型に合わせるためのキャスト。
-    // 不正値は Rust 側の `validate()` で検出される。
+    // 不正値は Rust 側 serde が deserialize 段階で reject する (PunctuationStyle enum)。
     punctuation_style: (punc?.value || '、。') as Config['punctuation_style'],
   };
 

--- a/muhenkan-switch/frontend/src/lib/config.ts
+++ b/muhenkan-switch/frontend/src/lib/config.ts
@@ -41,7 +41,7 @@ export interface Config {
   /**
    * 句読点スタイル。kanata の kbd ファイルに反映される。
    */
-  punctuation_style: '、。' | '，．' | '，。' | '、．';
+  punctuation_style: PunctuationStyle;
 }
 
 /**
@@ -57,6 +57,12 @@ export interface FolderEntry {
    */
   path: string;
 }
+
+/**
+ * 句読点スタイル。kanata の kbd ファイルに反映される 4 種類。
+ * TOML / JSON 上は `"、。"` のような文字列リテラルで表現される。
+ */
+export type PunctuationStyle = '、。' | '，．' | '，。' | '、．';
 
 /**
  * 検索エンジンエントリ。割当キーで起動し、URL テンプレートにクエリを差し込んで検索する。


### PR DESCRIPTION
Closes #178

## 概要

`Config.punctuation_style` を `String` から `enum PunctuationStyle` に置換し、`validate()` の literal array チェックを廃止して型でガードする。ts-rs の `#[ts(type = "...")]` 手書きアノテーションも削除し、Rust enum + `#[serde(rename)]` から ts-rs v12 が literal union を自動生成する形に統一。

## 変更点

### Rust (`muhenkan-switch-config/src/lib.rs`)
- `PunctuationStyle` enum 4 variant 追加 (`TenMaru` / `CommaPeriod` / `CommaMaru` / `TenPeriod`)、`#[serde(rename = "、。" / "，．" / "，。" / "、．")]` で TOML 文字列値と相互変換
- `Config.punctuation_style` の型を `String` → `PunctuationStyle` に
- `default_punctuation_style()` を廃止、`#[derive(Default)] + #[default]` で `TenMaru` をデフォルトに
- `validate()` の literal array チェック削除 (型ガード化)
- `rewrite_kbd_punctuation` のシグネチャを `&str` → `&PunctuationStyle` に変更

### Rust (`muhenkan-switch-config/src/svg.rs`)
- `text_edit_label(key, &PunctuationStyle)` に変更、match を enum match 化

### Frontend (生成物のみ)
- `frontend/src/lib/config.ts`: ts-rs 再生成で `export type PunctuationStyle = '、。' | '，．' | '，。' | '、．'` が独立 type として出力 (`Config.punctuation_style: PunctuationStyle`)。値域は完全等価、構造的型互換で既存 frontend コードは無変更で動作

### テスト
- 既存 4 箇所 (lib.rs / core/commands テスト) の `Config { punctuation_style: "、。".to_string(), ... }` を `Default::default()` に置換
- 新規 3 ケース追加 (lib.rs):
  - 4 variant ラウンドトリップ (既存 config.toml 互換性担保)
  - 省略時 `TenMaru` デフォルト適用
  - 不正文字列 reject (型ガード)

### TOML / 設定
- `config/default*.toml` 無変更 (serde 互換性維持)

## ローカル CI

- `cargo test --workspace`: 全 green (config: 38, core: 27)
- `mise run gen-ts`: 冪等 (再実行で sha256 一致)
- `npm run typecheck` / `lint` / `format:check` / `test` / `build`: 全 pass、coverage 100%

## Reviewer 確認ポイント (Coder からの △ 報告)

TS 側の型表現が「等価な literal union」だが「現状と完全等価」ではない:
- 値域: `'、。' | '，．' | '，。' | '，．'` (完全等価)
- 表現: 現状はインライン union → 変更後は独立 `export type PunctuationStyle` を `Config` が参照

ts-rs v12 のデフォルト挙動 (enum を別 type として export) で、Rust 型と TS 型の対応が直感的になる点で望ましいと判断。`#[ts(inline)]` でインライン化も可能だが採用せず。