### PR TITLE
fix(install): get.sh のパイプ実行ガードを set より前に移動

### DIFF
--- a/scripts/install/get.sh
+++ b/scripts/install/get.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # muhenkan-switch ワンライナーインストーラー
 #
@@ -9,14 +8,18 @@ set -euo pipefail
 # パイプ実行時は一時ファイルに保存してから bash で実行するため、
 # install スクリプト内の read プロンプトも正常に動作します。
 
-# ── パイプ実行ガード ──
-# stdin がパイプの場合、スクリプト全体を一時ファイルに書き出して再実行する
+# ── パイプ実行ガード (set より前に置く) ──
+# stdin がパイプの場合、スクリプト全体を一時ファイルに書き出して bash で再実行する。
+# `curl ... | sh` で dash 等の POSIX shell に投入されるケースがあるため、
+# bash 専用の `set -o pipefail` を有効化する前にガードする必要がある。
 if [ ! -t 0 ]; then
     tmp_script=$(mktemp)
     cat > "$tmp_script"
     exec bash "$tmp_script" "$@"
     # exec で置き換わるため、ここには到達しない
 fi
+
+set -euo pipefail
 
 # ── 設定 ──
 REPO="kimushun1101/muhenkan-switch"


### PR DESCRIPTION
## Summary

- `curl ... | sh` でインストールするとき、Ubuntu の `sh` (dash) で `set -o pipefail` が 2 行目で落ち、bash 再 exec ガードまで到達していなかった
- パイプ実行ガード (`[ ! -t 0 ]` で bash 再 exec) を `set -euo pipefail` より前に移動して修正
- 先頭は POSIX 互換のみで書く

## 検証

修正前 (v0.9.1):

```
$ git show v0.9.1:scripts/install/get.sh | head -25 | dash
dash: 2: set: Illegal option -o pipefail
```

修正後:

```
$ cat scripts/install/get.sh | head -25 | dash
(エラーなく通過)
```

## Test plan

- [ ] Ubuntu で `curl -fsSL .../get.sh | sh` がエラーなく走ること

Closes #183