### PR TITLE
release: v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.9.1 → v0.10.0 リリース用 version bump。

- `Cargo.toml` workspace.package.version
- `muhenkan-switch/tauri.conf.json` version
- `Cargo.lock` 同期

## v0.9.1 → v0.10.0 主要変更

### フロントエンド全面刷新
- `main.js` (798行) を機能別モジュールに分割し全 `.ts` 化 (Phase 3)
- Vite + `@tauri-apps/api` 採用、`window.__TAURI__` 直叩き廃止
- ESLint + Prettier 導入 (Phase 4-B)
- Vitest + happy-dom 導入、per-file 80% coverage 閾値を CI で強制 (Phase 4-C)
- `ts-rs` で Config 系 type を Rust から自動生成、IPC 型を `lib/ipc-types.ts` に集約

### 機能変更
- 最下段キー (Z/X/C/V/B) の挙動再設計・簡略化、Toast/エラー日本語化
- Wayland 分岐削除、X11 専用にクリーンアップ
- Linux 通知を `notify-rust` に切替、二重表示 fix
- アプリ切り替えに PID ベース fallback
- プリセット: Brave / Terminator / Ghostty 追加
- カスタマイズ枠デフォルトパス `~/repos` → `~/proj`、フォルダ順を Home 起点に
- インストーラ get.sh を POSIX 互換に修正 (#184 #186)

### CI / ビルド / ドキュメント
- PR トリガー workflow 追加、setup-node / action-gh-release bump
- mise Rust 1.95
- ファイル整理 (`legacy/`, `kanata/README.md` 削除)
- `docs/customize.md`, `docs/tips.md` 新設、README にデモ gif

## Release flow

このマージ後、main に `v0.10.0` タグを打って push → `.github/workflows/release.yml` が起動しビルド成果物が Release に添付される。