### PR TITLE
fix(install): バイナリ操作前に muhenkan-switch / kanata を停止する

### DIFF
--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -60,6 +60,21 @@ echo ""
 mkdir -p "$INSTALL_DIR"
 mkdir -p "$BIN_DIR"
 
+# ── 実行中のプロセスを停止 ──
+# バイナリ上書き時の競合を防ぐ
+if pgrep -x "muhenkan-switch" >/dev/null 2>&1; then
+    echo "実行中の muhenkan-switch を停止しています..."
+    pkill -x "muhenkan-switch" 2>/dev/null || true
+    sleep 1
+    echo "[OK] muhenkan-switch を停止しました"
+fi
+if pgrep -x "kanata_cmd_allowed" >/dev/null 2>&1; then
+    echo "実行中の kanata を停止しています..."
+    pkill -x "kanata_cmd_allowed" 2>/dev/null || true
+    sleep 1
+    echo "[OK] kanata を停止しました"
+fi
+
 # ── config.toml のバックアップ ──
 if [ -f "$INSTALL_DIR/config.toml" ]; then
     backup_name="config.toml.backup.$(date +%Y%m%d%H%M%S)"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -28,6 +28,21 @@ echo ""
 mkdir -p "$INSTALL_DIR"
 mkdir -p "$BIN_DIR"
 
+# ── 実行中のプロセスを停止 ──
+# バイナリ上書き時に `Text file busy` で失敗するのを防ぐ
+if pgrep -f "$INSTALL_DIR/muhenkan-switch$" >/dev/null 2>&1; then
+    echo "実行中の muhenkan-switch を停止しています..."
+    pkill -f "$INSTALL_DIR/muhenkan-switch$" 2>/dev/null || true
+    sleep 1
+    echo "[OK] muhenkan-switch を停止しました"
+fi
+if pgrep -f "$INSTALL_DIR/kanata_cmd_allowed" >/dev/null 2>&1; then
+    echo "実行中の kanata を停止しています..."
+    pkill -f "$INSTALL_DIR/kanata_cmd_allowed" 2>/dev/null || true
+    sleep 1
+    echo "[OK] kanata を停止しました"
+fi
+
 # ── config.toml のバックアップ ──
 if [ -f "$INSTALL_DIR/config.toml" ]; then
     backup_name="config.toml.backup.$(date +%Y%m%d%H%M%S)"

--- a/scripts/install/uninstall-macos.sh
+++ b/scripts/install/uninstall-macos.sh
@@ -36,13 +36,19 @@ if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
     exit 0
 fi
 
-# ── GUI プロセス停止 ──
+# ── 実行中のプロセスを停止 ──
 if pgrep -x "muhenkan-switch" > /dev/null 2>&1; then
     echo ""
     echo "muhenkan-switch プロセスを停止しています..."
     pkill -x "muhenkan-switch" 2>/dev/null || true
     sleep 1
     echo "[OK] muhenkan-switch プロセスを停止しました"
+fi
+if pgrep -x "kanata_cmd_allowed" > /dev/null 2>&1; then
+    echo "kanata プロセスを停止しています..."
+    pkill -x "kanata_cmd_allowed" 2>/dev/null || true
+    sleep 1
+    echo "[OK] kanata プロセスを停止しました"
 fi
 
 # ── launchd エージェント停止・削除 ──

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -43,6 +43,22 @@ if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
     exit 0
 fi
 
+# ── 実行中のプロセスを停止 ──
+# rm -rf 自体は実行中バイナリでも通るが、kanata が孤児化するのを防ぐ
+if pgrep -f "$INSTALL_DIR/muhenkan-switch$" >/dev/null 2>&1; then
+    echo ""
+    echo "実行中の muhenkan-switch を停止しています..."
+    pkill -f "$INSTALL_DIR/muhenkan-switch$" 2>/dev/null || true
+    sleep 1
+    echo "[OK] muhenkan-switch を停止しました"
+fi
+if pgrep -f "$INSTALL_DIR/kanata_cmd_allowed" >/dev/null 2>&1; then
+    echo "実行中の kanata を停止しています..."
+    pkill -f "$INSTALL_DIR/kanata_cmd_allowed" 2>/dev/null || true
+    sleep 1
+    echo "[OK] kanata を停止しました"
+fi
+
 # ── systemd サービス停止・削除（互換性）──
 if [ -f "$SERVICE_FILE" ]; then
     echo ""


### PR DESCRIPTION
## Summary

v0.9.1 → v0.10.0 アップデート検証で再現した 2 件を修正:

- **install.sh (update 経由)**: GUI 起動中の `cp` が `Text file busy` で失敗 → `cp` 前にプロセス停止
- **uninstall.sh**: 削除前に GUI/kanata を停止していない → kanata が孤児化 → `rm -rf` 前にプロセス停止

macOS の `install-macos.sh` / `uninstall-macos.sh` にも同パターンを適用。
`uninstall-macos.sh` は既に GUI 停止コードがあるので、kanata 停止のみ追加。

## 差分

- Linux: `pkill -f "$INSTALL_DIR/muhenkan-switch$"` (パス指定マッチで安全)
- macOS: `pkill -x "muhenkan-switch"` (既存 uninstall-macos.sh と統一)

## Test plan

- [x] Linux: bash -n syntax check
- [ ] Linux: GUI 起動中の update が成功する (要マージ前検証)
- [ ] Linux: GUI 起動中の uninstall でゾンビ kanata が残らない
- [ ] Linux: 何も起動していない状態の install で no-op (正常終了)
- [ ] macOS: 同パターン適用、ローカル検証は未実施 (リリース後に動作確認)

## マージ前検証

このブランチの install/uninstall スクリプトを使うため、新規 release は不要。ローカル checkout して直接実行:

```bash
git fetch origin fix/issue-188
git checkout fix/issue-188
# GUI 起動中に
bash scripts/install/install.sh  # ※展開された zip 内で実行する想定。直接呼ぶならパス調整必要
```

実環境テストは次の release で curl 経由検証が現実的。

Closes #188