### PR TITLE
feat(install): 完了前に「muhenkan-switch を今すぐ起動しますか？」を追加

### DIFF
--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -204,6 +204,15 @@ echo ""
 echo "詳細は kanata のリリースページを参照してください:"
 echo "  https://github.com/jtroo/kanata/releases"
 
+# ── 今すぐ起動（オプション）──
+echo ""
+read -rp "muhenkan-switch を今すぐ起動しますか？ (y/N): " start_now
+if [ "$start_now" = "y" ] || [ "$start_now" = "Y" ]; then
+    nohup "$INSTALL_DIR/muhenkan-switch" >/dev/null 2>&1 &
+    disown
+    echo "[OK] muhenkan-switch を起動しました"
+fi
+
 # ── 完了 ──
 echo ""
 echo "=== インストール完了 ==="

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -250,6 +250,15 @@ echo "  sudo udevadm control --reload-rules && sudo udevadm trigger"
 echo ""
 echo "  ※ 設定後、再ログインが必要です"
 
+# ── 今すぐ起動（オプション）──
+echo ""
+read -rp "muhenkan-switch を今すぐ起動しますか？ (y/N): " start_now
+if [ "$start_now" = "y" ] || [ "$start_now" = "Y" ]; then
+    nohup "$INSTALL_DIR/muhenkan-switch" >/dev/null 2>&1 &
+    disown
+    echo "[OK] muhenkan-switch を起動しました"
+fi
+
 # ── 完了 ──
 echo ""
 echo "=== インストール完了 ==="


### PR DESCRIPTION
## Summary

`install.sh` / `install-macos.sh` の完了直前に起動プロンプトを追加。
y なら `nohup ... &` でバックグラウンド起動し、`disown` でターミナル
を閉じても GUI が残る。

配置は **uinput (Linux) / Karabiner (macOS) 設定の案内後**:
初回 install で依存設定が未完了のユーザーが意図せず起動して、
kanata が起動できず混乱する事態を避けるため。

## Test plan

- [ ] Linux: y で nohup 起動、ターミナル閉じても GUI が残る
- [ ] Linux: N で起動せず終了
- [ ] macOS: 同等動作 (未検証)

## マージ前検証

このブランチを fetch して install.sh を実行:

```bash
git fetch origin fix/issue-189
git checkout fix/issue-189
bash scripts/install/install.sh  # ※展開済 zip 内での実行を想定
```

Closes #189