### PR TITLE
fix(install): kanata バイナリのバージョンチェックと再ダウンロード

### DIFF
--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -93,10 +93,22 @@ chmod +x "$INSTALL_DIR/muhenkan-switch-core" 2>/dev/null || true
 
 # ── kanata ダウンロード ──
 kanata_dest="$INSTALL_DIR/kanata_cmd_allowed"
+download_kanata=true
+
 if [ -f "$kanata_dest" ]; then
-    echo "[SKIP] kanata_cmd_allowed は既にインストール済みです"
-    echo "       再ダウンロードする場合は削除してから再実行してください"
-else
+    # 出力例: "kanata 1.11.0"
+    current_kanata_version=$("$kanata_dest" --version 2>/dev/null | awk '/^kanata/{print $2; exit}' || true)
+    expected_kanata_version="${KANATA_VERSION#v}"
+    if [ "$current_kanata_version" = "$expected_kanata_version" ]; then
+        echo "[SKIP] kanata $KANATA_VERSION は既にインストール済みです"
+        download_kanata=false
+    else
+        echo "kanata バージョン不一致 (現在: v${current_kanata_version:-不明} → 期待: $KANATA_VERSION)"
+        echo "再ダウンロードします..."
+    fi
+fi
+
+if [ "$download_kanata" = "true" ]; then
     echo ""
     echo "kanata $KANATA_VERSION ($ARCH) をダウンロードしています..."
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -82,10 +82,22 @@ chmod +x "$INSTALL_DIR/muhenkan-switch-core" 2>/dev/null || true
 
 # ── kanata ダウンロード ──
 kanata_dest="$INSTALL_DIR/kanata_cmd_allowed"
+download_kanata=true
+
 if [ -f "$kanata_dest" ]; then
-    echo "[SKIP] kanata_cmd_allowed は既にインストール済みです"
-    echo "       再ダウンロードする場合は削除してから再実行してください"
-else
+    # 出力例: "kanata 1.11.0"
+    current_kanata_version=$("$kanata_dest" --version 2>/dev/null | awk '/^kanata/{print $2; exit}' || true)
+    expected_kanata_version="${KANATA_VERSION#v}"
+    if [ "$current_kanata_version" = "$expected_kanata_version" ]; then
+        echo "[SKIP] kanata $KANATA_VERSION は既にインストール済みです"
+        download_kanata=false
+    else
+        echo "kanata バージョン不一致 (現在: v${current_kanata_version:-不明} → 期待: $KANATA_VERSION)"
+        echo "再ダウンロードします..."
+    fi
+fi
+
+if [ "$download_kanata" = "true" ]; then
     echo ""
     echo "kanata $KANATA_VERSION をダウンロードしています..."
 


### PR DESCRIPTION
## Summary

既存の `kanata_cmd_allowed` があれば無条件 SKIP していたため、
`kanata-version.txt` を bump してリリースしてもユーザー環境の
kanata が古いまま放置されていた。

## 実装

`kanata_cmd_allowed --version` の出力 (確認済み: `kanata 1.11.0`) を
期待バージョン (`KANATA_VERSION`) と比較:

```bash
current_kanata_version=$("$kanata_dest" --version 2>/dev/null | awk '/^kanata/{print $2; exit}' || true)
expected_kanata_version="${KANATA_VERSION#v}"
if [ "$current_kanata_version" = "$expected_kanata_version" ]; then
    # SKIP
else
    # 再ダウンロード
fi
```

- バージョン取得失敗 (バイナリ破損等) → 空文字列 → 不一致扱いで再 DL (回復)
- `install-macos.sh` も同パターン (未検証)

## Test plan

- [ ] Linux: 同バージョンなら SKIP メッセージ
- [ ] Linux: バージョン違いなら「kanata バージョン不一致」表示 → 再 DL
- [ ] Linux: バイナリが壊れている (or version 出力が空) なら再 DL
- [ ] macOS: 同等 (未検証)

Closes #190