### PR TITLE
fix(install): config.toml は既存保持、muhenkan.kbd はバックアップ→上書き

### DIFF
--- a/scripts/install/install-macos.sh
+++ b/scripts/install/install-macos.sh
@@ -75,11 +75,18 @@ if pgrep -x "kanata_cmd_allowed" >/dev/null 2>&1; then
     echo "[OK] kanata を停止しました"
 fi
 
-# ── config.toml のバックアップ ──
+# ── 既存ファイルの保護とバックアップ ──
+# config.toml: ユーザーカスタマイズ保護のため既存があれば保持 (バックアップは保険)
+# muhenkan-macos.kbd: 新版で上書きするが、ユーザー編集を救えるようバックアップを取る
 if [ -f "$INSTALL_DIR/config.toml" ]; then
     backup_name="config.toml.backup.$(date +%Y%m%d%H%M%S)"
     cp "$INSTALL_DIR/config.toml" "$INSTALL_DIR/$backup_name"
-    echo "[OK] 既存の config.toml をバックアップしました: $backup_name"
+    echo "[OK] 既存の config.toml を保持しました (バックアップ: $backup_name)"
+fi
+if [ -f "$INSTALL_DIR/muhenkan-macos.kbd" ]; then
+    backup_name="muhenkan-macos.kbd.backup.$(date +%Y%m%d%H%M%S)"
+    cp "$INSTALL_DIR/muhenkan-macos.kbd" "$INSTALL_DIR/$backup_name"
+    echo "[OK] 既存の muhenkan-macos.kbd をバックアップしました: $backup_name"
 fi
 
 # ── ファイルコピー ──
@@ -97,7 +104,10 @@ copy_file() {
 
 copy_file "muhenkan-switch" "muhenkan-switch"
 copy_file "muhenkan-switch-core" "muhenkan-switch-core"
-copy_file "config.toml" "config.toml"
+# config.toml は既存があれば保持 (バックアップは上記で取得済み)
+if [ ! -f "$INSTALL_DIR/config.toml" ]; then
+    copy_file "config.toml" "config.toml"
+fi
 copy_file "muhenkan-macos.kbd" "muhenkan-macos.kbd"
 copy_file "update-macos.sh" "update-macos.sh"
 copy_file "uninstall-macos.sh" "uninstall-macos.sh"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -43,11 +43,18 @@ if pgrep -f "$INSTALL_DIR/kanata_cmd_allowed" >/dev/null 2>&1; then
     echo "[OK] kanata を停止しました"
 fi
 
-# ── config.toml のバックアップ ──
+# ── 既存ファイルの保護とバックアップ ──
+# config.toml: ユーザーカスタマイズ保護のため既存があれば保持 (バックアップは保険)
+# muhenkan.kbd: 新版で上書きするが、ユーザー編集を救えるようバックアップを取る
 if [ -f "$INSTALL_DIR/config.toml" ]; then
     backup_name="config.toml.backup.$(date +%Y%m%d%H%M%S)"
     cp "$INSTALL_DIR/config.toml" "$INSTALL_DIR/$backup_name"
-    echo "[OK] 既存の config.toml をバックアップしました: $backup_name"
+    echo "[OK] 既存の config.toml を保持しました (バックアップ: $backup_name)"
+fi
+if [ -f "$INSTALL_DIR/muhenkan.kbd" ]; then
+    backup_name="muhenkan.kbd.backup.$(date +%Y%m%d%H%M%S)"
+    cp "$INSTALL_DIR/muhenkan.kbd" "$INSTALL_DIR/$backup_name"
+    echo "[OK] 既存の muhenkan.kbd をバックアップしました: $backup_name"
 fi
 
 # ── ファイルコピー ──
@@ -65,7 +72,10 @@ copy_file() {
 
 copy_file "muhenkan-switch" "muhenkan-switch"
 copy_file "muhenkan-switch-core" "muhenkan-switch-core"
-copy_file "config.toml" "config.toml"
+# config.toml は既存があれば保持 (バックアップは上記で取得済み)
+if [ ! -f "$INSTALL_DIR/config.toml" ]; then
+    copy_file "config.toml" "config.toml"
+fi
 copy_file "muhenkan.kbd" "muhenkan.kbd"
 copy_file "update.sh" "update.sh"
 copy_file "uninstall.sh" "uninstall.sh"


### PR DESCRIPTION
## Summary

update 時にユーザーのカスタマイズが消えていた問題を修正:

- **config.toml**: 無条件上書き → 既存あれば保持 (バックアップは保険)
- **muhenkan.kbd**: バックアップなし上書き → バックアップしてから上書き

`install-macos.sh` も `muhenkan-macos.kbd` で同パターン (未検証)。

## 設計判断

- `config.toml` は新しい設定フィールドが追加される可能性があるが、本 PR
  のスコープ外。ユーザーが default に戻したい場合は `config.toml` を
  手動削除してから再インストールする運用 (ドキュメント追記は別 Issue)
- `muhenkan.kbd` は kanata の動作に直結し、kanata bump で書式変更の
  可能性があるため最新版を入れる。ユーザー編集は backup で救う

## Test plan

- [ ] 既存 config.toml がある状態で再インストール → 内容保持・バックアップ作成
- [ ] 初回インストール (config.toml 無し) → default が入る
- [ ] muhenkan.kbd が backup された上で新版が入る
- [ ] macOS: 同等動作 (未検証)

Closes #191