### PR TITLE
feat(updater): Linux/macOS で GitHub API + ターミナル経由のアップデート通知

### DIFF
--- a/muhenkan-switch/frontend/src/forms/general.ts
+++ b/muhenkan-switch/frontend/src/forms/general.ts
@@ -33,7 +33,7 @@ export async function loadAutostart(): Promise<void> {
   }
 }
 
-// ── Updater ──
+// ── Updater (installer: Windows / tauri-plugin-updater) ──
 async function checkForUpdate(silent = true): Promise<void> {
   try {
     const currentVersion = await invoke<string>('get_app_version');
@@ -49,6 +49,56 @@ async function checkForUpdate(silent = true): Promise<void> {
       }
     } else if (!silent) {
       await message(`v${currentVersion} は最新です。`, { title: 'アップデート' });
+    }
+  } catch (e) {
+    console.error('[updater]', e);
+    if (!silent)
+      await message('アップデート確認に失敗しました:\n' + String(e), {
+        title: 'エラー',
+        kind: 'error',
+      });
+  }
+}
+
+// ── Updater (script: Linux/macOS / GitHub API + terminal spawn) ──
+const GITHUB_LATEST_RELEASE_URL =
+  'https://api.github.com/repos/kimushun1101/muhenkan-switch/releases/latest';
+
+async function checkGithubLatestRelease(silent = true): Promise<void> {
+  try {
+    const currentVersion = await invoke<string>('get_app_version');
+    const res = await fetch(GITHUB_LATEST_RELEASE_URL);
+    if (!res.ok) {
+      throw new Error(`GitHub API エラー: HTTP ${res.status}`);
+    }
+    const release = (await res.json()) as { tag_name?: string };
+    if (!release.tag_name) {
+      throw new Error('tag_name が取得できませんでした');
+    }
+    const latestVersion = release.tag_name.replace(/^v/, '');
+
+    if (latestVersion === currentVersion) {
+      if (!silent) {
+        await message(`v${currentVersion} は最新です。`, { title: 'アップデート' });
+      }
+      return;
+    }
+
+    const proceed = await ask(
+      `現在: v${currentVersion} → 最新: v${latestVersion}\n\n` +
+        `ターミナルでアップデートを実行しますか？`,
+      { title: 'アップデート' },
+    );
+    if (!proceed) return;
+
+    try {
+      await invoke('spawn_update_terminal');
+    } catch (e) {
+      await message(
+        `ターミナルの起動に失敗しました:\n${String(e)}\n\n` +
+          `手動で update.sh / update-macos.sh を実行してください。`,
+        { title: 'エラー', kind: 'error' },
+      );
     }
   } catch (e) {
     console.error('[updater]', e);
@@ -147,13 +197,15 @@ export function initGeneralForm({ renderConfig }: InitGeneralFormOptions): void 
 
 // ── Updater initialization (called from main init after install type check) ──
 export async function initUpdater(): Promise<void> {
-  // インストーラー版のみ自動更新チェック
   const installType = await invoke<string>('get_install_type');
-  if (installType === 'installer') {
-    // 起動 5 秒後にサイレントチェック
-    setTimeout(() => void checkForUpdate(true), 5000);
+  // installer (Windows): tauri-plugin-updater 経由
+  // script (Linux/macOS): GitHub API + ターミナルで update スクリプト spawn
+  const check: (silent?: boolean) => Promise<void> =
+    installType === 'installer' ? checkForUpdate : checkGithubLatestRelease;
 
-    // トレイメニューからの手動チェック (payload なしイベント)
-    void listen('check-update-requested', () => void checkForUpdate(false));
-  }
+  // 起動 5 秒後にサイレントチェック
+  setTimeout(() => void check(true), 5000);
+
+  // トレイメニュー「アップデートを確認...」からの手動チェック
+  void listen('check-update-requested', () => void check(false));
 }

--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -387,6 +387,75 @@ pub fn get_install_type() -> String {
     }
 }
 
+/// Linux/macOS でターミナルを開いて update スクリプトを実行する。
+/// Windows では tauri-plugin-updater を使うため、呼ばれることはない想定。
+#[tauri::command]
+pub fn spawn_update_terminal() -> Result<(), String> {
+    use std::process::Command;
+
+    #[cfg(target_os = "linux")]
+    {
+        let home = dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
+        let script = home.join(".local/share/muhenkan-switch/update.sh");
+        if !script.exists() {
+            return Err(format!(
+                "update.sh が見つかりません: {}",
+                script.display()
+            ));
+        }
+        let bash_cmd = format!(
+            "{}; echo; echo 'Press Enter to close'; read",
+            script.display()
+        );
+
+        // $TERMINAL → x-terminal-emulator → 主要候補の順に試行
+        let mut candidates: Vec<(String, Vec<&str>)> = Vec::new();
+        if let Ok(term) = std::env::var("TERMINAL") {
+            candidates.push((term, vec!["-e", "bash", "-c"]));
+        }
+        candidates.push(("x-terminal-emulator".to_string(), vec!["-e", "bash", "-c"]));
+        candidates.push(("gnome-terminal".to_string(), vec!["--", "bash", "-c"]));
+        candidates.push(("konsole".to_string(), vec!["-e", "bash", "-c"]));
+        candidates.push(("xterm".to_string(), vec!["-e", "bash", "-c"]));
+
+        for (term, args) in &candidates {
+            let mut cmd = Command::new(term);
+            for a in args {
+                cmd.arg(a);
+            }
+            cmd.arg(&bash_cmd);
+            if cmd.spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        Err("ターミナルエミュレータが見つかりません (TERMINAL/x-terminal-emulator/gnome-terminal/konsole/xterm をインストールしてください)".to_string())
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir().ok_or_else(|| "ホームディレクトリが見つかりません".to_string())?;
+        let script = home.join("Library/Application Support/muhenkan-switch/update-macos.sh");
+        if !script.exists() {
+            return Err(format!(
+                "update-macos.sh が見つかりません: {}",
+                script.display()
+            ));
+        }
+        Command::new("open")
+            .arg("-a")
+            .arg("Terminal.app")
+            .arg(&script)
+            .spawn()
+            .map_err(|e| format!("Terminal.app の起動に失敗しました: {}", e))?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err("このプラットフォームではサポートされていません".to_string())
+    }
+}
+
 // ── Utility commands ──
 
 #[tauri::command]

--- a/muhenkan-switch/src/main.rs
+++ b/muhenkan-switch/src/main.rs
@@ -64,6 +64,7 @@ fn main() {
             commands::check_update,
             commands::install_update,
             commands::get_install_type,
+            commands::spawn_update_terminal,
         ])
         .setup(|app| {
             // 初回起動時 or 壊れた config.toml の再生成

--- a/muhenkan-switch/src/tray.rs
+++ b/muhenkan-switch/src/tray.rs
@@ -21,24 +21,21 @@ fn build_tray(handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             .build(handle)?;
     let open_dir_item = MenuItemBuilder::with_id("open_dir", "インストール先を開く")
         .build(handle)?;
-    let is_installer = crate::commands::is_nsis_install();
-    let check_update_item = if is_installer {
-        Some(MenuItemBuilder::with_id("check_update", "アップデートを確認...").build(handle)?)
-    } else {
-        None
-    };
+    // インストーラー版 / スクリプト版どちらでも表示する。
+    // listener 側 (initUpdater) で install type ごとに振り分け:
+    //   - installer (Windows): tauri-plugin-updater 経由
+    //   - script (Linux/macOS): GitHub API + ターミナル spawn
+    let check_update_item =
+        MenuItemBuilder::with_id("check_update", "アップデートを確認...").build(handle)?;
     let sep3 = PredefinedMenuItem::separator(handle)?;
     let quit_item = MenuItemBuilder::with_id("quit", "終了").build(handle)?;
 
-    let mut menu = MenuBuilder::new(handle)
+    let menu = MenuBuilder::new(handle)
         .item(&settings_item)
         .item(&sep1)
         .item(&autostart_item)
-        .item(&open_dir_item);
-    if let Some(ref item) = check_update_item {
-        menu = menu.item(item);
-    }
-    let menu = menu
+        .item(&open_dir_item)
+        .item(&check_update_item)
         .item(&sep3)
         .item(&quit_item)
         .build()?;


### PR DESCRIPTION
## Summary

これまで非 Windows では auto-check も tray メニューも無効化されていたため、Linux/macOS ユーザーは手動で `update.sh` を叩く以外に新版を知る術がなかった。GitHub API で最新版を確認し、ダイアログ → ターミナル起動の動線を追加。

## 構成

### Frontend (`general.ts`)
- `checkGithubLatestRelease(silent)` を新設: `fetch()` で GitHub Releases API を叩き、現在 version と比較してダイアログ表示
- ユーザーが [はい] なら `invoke('spawn_update_terminal')` を呼ぶ
- `initUpdater()` を install type で分岐:
  - `installer` (Windows): 既存の `tauri-plugin-updater` 経路
  - `script` (Linux/macOS): 新設の `checkGithubLatestRelease` 経路
- 起動 5 秒後のサイレントチェック + tray メニュー listener を両系統で共有

### Rust (`commands.rs`)
- `spawn_update_terminal()` コマンドを追加:
  - **Linux**: `$TERMINAL` → `x-terminal-emulator` → `gnome-terminal` → `konsole` → `xterm` の順でターミナル起動を試行
  - **macOS**: `open -a Terminal.app /path/to/update-macos.sh`
  - **Windows**: error (呼ばれない想定)
- bash で `update.sh ; echo 'Press Enter to close' ; read` を実行、完了後に Enter 待ちでターミナルを開いたままにする

### Tray (`tray.rs`)
- 「アップデートを確認...」を install type に関わらず常に表示
- 動作 (Windows = tauri-updater / 非 Windows = GitHub API) は listener 側で振り分け

## UX フロー (Linux)

```
[アプリ起動 5秒後]
   ↓
[GitHub API で最新確認]
   ↓
[新版あり → 「v0.x → v0.y、ターミナルで実行しますか？」ダイアログ]
   ↓
[ユーザー [はい]]
   ↓
[ターミナル window が開く (gnome-terminal 等)]
   ↓
[update.sh 実行: ダウンロード → 展開 → install.sh]
   ↓
[install.sh のプロンプトに応答 (#189 で起動 prompt も追加)]
   ↓
[完了後 "Press Enter to close" で待機]
```

## 検証済

- [x] TypeScript typecheck (tsc --noEmit)
- [x] ESLint
- [x] Prettier format:check
- [x] Vitest (34 tests pass, coverage 100% on included files)
- [x] Vite build
- [x] Rust cargo check
- [x] Rust cargo test --workspace (65 tests pass)

## Test plan (動作確認)

- [ ] Linux: 起動 5秒後に GitHub API call、新版があればダイアログ
- [ ] Linux: ダイアログ [はい] → ターミナルが開いて update.sh が走る
- [ ] Linux: 各ターミナル emulator のフォールバックが動作
- [ ] Linux: tray メニュー「アップデートを確認...」が表示・動作
- [ ] Windows: 既存挙動 (tauri-updater) に regression なし
- [ ] macOS: 同等動作 (未検証)

## 関連

- #192 (closed as already implemented): 非 Windows の auto-check skip は既にコードで実現済み
- #189: install.sh の起動プロンプトと組み合わせると、update スクリプト完了後の起動まで連動

Closes #193