### PR TITLE
release: v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.10.0 → v0.11.0 リリース用 version bump。

## v0.10.0 → v0.11.0 主要変更

### インストーラ改善 (Linux/macOS)
- **#194**: install/uninstall でバイナリ操作前に muhenkan-switch / kanata プロセスを停止 (`Text file busy` 修正)
- **#195**: install 完了後に「muhenkan-switch を今すぐ起動しますか？」プロンプトを追加 (`nohup` 起動)
- **#196**: kanata バイナリのバージョンチェックと再ダウンロード (`kanata-version.txt` bump 時に追従)
- **#197**: `config.toml` は既存保持 (ユーザーカスタマイズ保護)、`muhenkan.kbd` はバックアップしてから上書き

### GUI アップデート機能 (Linux/macOS)
- **#198**: 起動 5秒後の auto-update を Windows 以外でも有効化
  - GitHub Releases API で最新版を確認 → ダイアログ → ターミナルで `update.sh` / `update-macos.sh` を起動
  - Linux ターミナル検出: `$TERMINAL` → `x-terminal-emulator` → gnome-terminal → konsole → xterm
  - macOS: `open -a Terminal.app`
  - トレイメニュー「アップデートを確認...」も全プラットフォームで表示

### マルチプラットフォーム
- macOS スクリプト (install/uninstall/update-macos.sh) も同パターン適用 (未検証)

## Release flow

このマージ後、main に `v0.11.0` タグを push → `.github/workflows/release.yml` が起動しビルド成果物が Release に添付される。