### PR TITLE
fix(install): WAYLAND_DISPLAY 未定義で set -u が落ちる

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -240,7 +240,7 @@ echo "     $APP_DESKTOP_FILE"
 
 # ── 外部ツールの確認 ──
 missing_tools=""
-if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
     for tool in wl-paste notify-send; do
         if ! command -v "$tool" &>/dev/null; then
             missing_tools="$missing_tools $tool"


### PR DESCRIPTION
## Summary

v0.10.0 → v0.11.0 アップデート検証中に発見:

```
install.sh: line 243: WAYLAND_DISPLAY: unbound variable
```

\`set -euo pipefail\` 環境下で \`$WAYLAND_DISPLAY\` (および \`$XDG_SESSION_TYPE\`) が unset の場合、\`-u\` で落ちて install.sh が中断。後続の uinput 案内と #195 で追加した「今すぐ起動しますか？」プロンプトに到達しない。

## 修正

両変数を default 展開に変更:

```bash
- if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+ if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
```

## 検証

```bash
( unset XDG_SESSION_TYPE WAYLAND_DISPLAY
  set -euo pipefail
  if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then ...
)
# → [OK] エラー無し
```

## 経緯

既存バグ。v0.10.0 以前から潜在していたが、#195 で起動プロンプトを最後に追加したことで「途中で死ぬとプロンプトが出ない」現象として顕在化。v0.11.0 アップデート検証で発見。

Closes #200