### PR TITLE
release: v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.11.0 → v0.11.1 パッチリリース。

## v0.11.0 → v0.11.1 変更点

- **#201** (Closes #200): \`install.sh\` で \`WAYLAND_DISPLAY\` 未定義時に \`set -u\` が落ちる既存バグ修正
  - X11 セッションで \`WAYLAND_DISPLAY\` が unset の環境 (例: 一部の端末 / SSH 経由) で install.sh が line 243 で中断していた
  - 結果として uinput 案内・「今すぐ起動しますか？」プロンプト (#195) に到達しなかった
  - \`${VAR:-}\` default 展開で修正

## Release flow

このマージ後、main に \`v0.11.1\` タグを push → CI が release を作る。

検証: v0.11.0 → v0.11.1 update で起動プロンプトまで到達すること。