### PR TITLE
fix(csp): connect-src で GitHub API への fetch を許可

### DIFF
--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -19,7 +19,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.github.com"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

v0.11.1 で tray「アップデートを確認...」を実行すると以下のエラー:

\`\`\`
アップデート確認に失敗しました:
TypeError: Load failed
\`\`\`

\`tauri.conf.json\` の prod CSP:

\`\`\`json
"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'"
\`\`\`

\`default-src 'self'\` は \`connect-src\` も含むため、#198 で追加した \`fetch('https://api.github.com/...')\` がブロックされる。

## 修正

\`connect-src\` を明示し \`api.github.com\` だけホワイトリスト追加:

\`\`\`json
"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.github.com"
\`\`\`

他の external endpoint は引き続きブロックされる (最小権限維持)。

## 関連

- #198 (GUI アップデート機能、CSP 想定漏れ)
- 既存の dev CSP (\`tauri.conf.dev.json\`) には Vite HMR 用の \`connect-src\` が既にあるため、開発時は問題なし。prod 専用バグ

Closes #203