### PR TITLE
release: v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.11.1 → v0.11.2 パッチリリース。

## v0.11.1 → v0.11.2 変更点

- **#204** (Closes #203): \`tauri.conf.json\` の CSP に \`connect-src 'self' https://api.github.com\` を追加
  - v0.11.1 で GUI アップデート機能 (#198) が CSP 制約で fetch 失敗していた:
    \`アップデート確認に失敗しました: TypeError: Load failed\`

## Release flow

このマージ後、main に \`v0.11.2\` タグを push → CI が release を作る。

検証: v0.11.1 → v0.11.2 update 後、tray「アップデートを確認...」で「最新です」ダイアログが正常表示。