### PR TITLE
fix(install): uinput 設定済みなら長文ガイドを SKIP

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -271,21 +271,38 @@ else
 fi
 
 # ── uinput グループ設定の案内 ──
+# 既に設定済みなら長文ガイドを省略する (update のたびに「再ログイン必要?」と
+# 誤解させないため)。id -nG は再ログイン後の真の membership を返すので、
+# 「グループ追加したが未ログイン」状態も正しく未設定扱いになる。
+uinput_groups_ok=false
+if id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx uinput \
+    && id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx input; then
+    uinput_groups_ok=true
+fi
+udev_rule_ok=false
+if [ -f /etc/udev/rules.d/99-uinput.rules ]; then
+    udev_rule_ok=true
+fi
+
 echo ""
-echo "── uinput グループ設定 ──"
-echo ""
-echo "kanata を sudo なしで実行するには、以下のコマンドを実行してください:"
-echo ""
-echo "  sudo groupadd -f uinput"
-echo "  sudo usermod -aG input \$USER"
-echo "  sudo usermod -aG uinput \$USER"
-echo ""
-echo "  echo 'KERNEL==\"uinput\", MODE=\"0660\", GROUP=\"uinput\", OPTIONS+=\"static_node=uinput\"' \\"
-echo "    | sudo tee /etc/udev/rules.d/99-uinput.rules"
-echo ""
-echo "  sudo udevadm control --reload-rules && sudo udevadm trigger"
-echo ""
-echo "  ※ 設定後、再ログインが必要です"
+if [ "$uinput_groups_ok" = "true" ] && [ "$udev_rule_ok" = "true" ]; then
+    echo "[OK] uinput 設定済み (再ログイン不要)"
+else
+    echo "── uinput グループ設定 ──"
+    echo ""
+    echo "kanata を sudo なしで実行するには、以下のコマンドを実行してください:"
+    echo ""
+    echo "  sudo groupadd -f uinput"
+    echo "  sudo usermod -aG input \$USER"
+    echo "  sudo usermod -aG uinput \$USER"
+    echo ""
+    echo "  echo 'KERNEL==\"uinput\", MODE=\"0660\", GROUP=\"uinput\", OPTIONS+=\"static_node=uinput\"' \\"
+    echo "    | sudo tee /etc/udev/rules.d/99-uinput.rules"
+    echo ""
+    echo "  sudo udevadm control --reload-rules && sudo udevadm trigger"
+    echo ""
+    echo "  ※ 設定後、再ログインが必要です"
+fi
 
 # ── 今すぐ起動（オプション）──
 echo ""


### PR DESCRIPTION
## Summary

update のたびに uinput グループ設定の長文ガイドが表示され、「アップデートごとに再ログインが必要?」とユーザーが誤解していた。uinput 設定は一度だけ必要。

## 実装

- `id -nG "$USER"` で input/uinput グループ membership を検出
- `/etc/udev/rules.d/99-uinput.rules` の存在で udev ルールを検出
- 両方揃っていれば「[OK] uinput 設定済み (再ログイン不要)」の 1 行表示
- 未設定なら従来の長文ガイド + 再ログイン案内

`id -nG` は **再ログイン後の真の membership** を返すため、「グループ追加したが未ログイン」状態も正しく未設定扱いになる (現セッションの `groups` ではこれを誤検出する)。

## 検証 (実環境)

設定済み環境で:

```
uinput_groups_ok=true
udev_rule_ok=true
id -nG: input uinput
/etc/udev/rules.d/99-uinput.rules 存在
```

→ 「[OK] uinput 設定済み (再ログイン不要)」表示を確認。

## Test plan

- [x] bash -n
- [x] 設定済み環境で SKIP 表示 (ローカル確認)
- [ ] 未設定環境で長文ガイド表示 (リリース後に確認可)

Closes #206