### PR TITLE
release: v0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.11.2 → v0.11.3 パッチリリース。

## v0.11.2 → v0.11.3 変更点

- **#207** (Closes #206): install.sh で uinput 設定済みなら長文ガイドを SKIP し「[OK] uinput 設定済み (再ログイン不要)」の 1 行表示に
  - update のたびに「アップデートごとに再ログイン必要?」という誤解を防ぐ

## Release flow

このマージ後、main に `v0.11.3` タグを push → CI が release を作る。

検証 (2 つ):
1. v0.11.2 GUI が v0.11.3 を検出 → auto-update の terminal spawn 経路 (#198 最終未検証部分)
2. update 後に uinput が「設定済み」1 行表示になる (#207)