### PR TITLE
fix(updater): auto-update 再起動の真っ白とターミナル早期クローズを修正

### DIFF
--- a/muhenkan-switch/src/commands.rs
+++ b/muhenkan-switch/src/commands.rs
@@ -403,8 +403,12 @@ pub fn spawn_update_terminal() -> Result<(), String> {
                 script.display()
             ));
         }
+        // GUI 自身が nohup 等で stdin=/dev/null で起動されていると、spawn された
+        // ターミナル内 bash の stdin も /dev/null を継承し、末尾の `read` が即 EOF
+        // を踏んでターミナルが早期に閉じることがある。`</dev/tty` で controlling
+        // terminal (= ターミナルエミュレータの PTY) から確実に読むようにする。
         let bash_cmd = format!(
-            "{}; echo; echo 'Press Enter to close'; read",
+            "{}; echo; echo 'Press Enter to close...'; read _ </dev/tty || true",
             script.display()
         );
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -308,8 +308,17 @@ fi
 echo ""
 read -rp "muhenkan-switch を今すぐ起動しますか？ (y/N): " start_now
 if [ "$start_now" = "y" ] || [ "$start_now" = "Y" ]; then
-    nohup "$INSTALL_DIR/muhenkan-switch" >/dev/null 2>&1 &
-    disown
+    # setsid で controlling terminal を持たない新セッションとして起動する。
+    # auto-update 経由 (GUI が spawn したターミナル内) で install.sh が走ると、
+    # ターミナルが早期に閉じて install.sh が orphan 化することがある。nohup &
+    # だけだと瀕死コンテキストを引き継いで WebKitGTK が真っ白になるため、
+    # setsid + stdin /dev/null でセッションを完全に切り離す。
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$INSTALL_DIR/muhenkan-switch" </dev/null >/dev/null 2>&1 &
+    else
+        nohup "$INSTALL_DIR/muhenkan-switch" </dev/null >/dev/null 2>&1 &
+        disown
+    fi
     echo "[OK] muhenkan-switch を起動しました"
 fi
 


### PR DESCRIPTION
## Summary

#198 の auto-update を実環境テスト中に発見した 2 バグを修正 (因果連鎖):

1. spawn ターミナルが「Press Enter」を待たず早期クローズ
2. → install.sh が orphan 化 → 瀕死コンテキストから nohup 起動した GUI が WebKitGTK で真っ白

## 修正

### install.sh (真っ白の直接対策)
\`nohup ... & disown\` → \`setsid ... </dev/null &\` でセッションを完全 detach。spawn 元ターミナルの生死に依存しなくなる。setsid 不在環境は nohup fallback。

\`\`\`bash
if command -v setsid >/dev/null 2>&1; then
    setsid "$INSTALL_DIR/muhenkan-switch" </dev/null >/dev/null 2>&1 &
else
    nohup "$INSTALL_DIR/muhenkan-switch" </dev/null >/dev/null 2>&1 &
    disown
fi
\`\`\`

### commands.rs spawn_update_terminal (早期クローズ対策)
GUI が stdin=/dev/null で起動されていると spawn ターミナル内 bash も /dev/null を継承し、末尾 \`read\` が即 EOF。\`read _ </dev/tty\` で controlling terminal (PTY) から確実に読む。

\`\`\`
- "{}; echo; echo 'Press Enter to close'; read"
+ "{}; echo; echo 'Press Enter to close...'; read _ </dev/tty || true"
\`\`\`

## 検証

- [x] bash -n install.sh
- [x] cargo check
- [ ] v0.11.4 リリース後、auto-update で再起動 GUI が真っ白にならない + ターミナルが Enter まで開いたまま (実環境)

## 注意

両修正とも起動コンテキスト依存のため、確実な検証は v0.11.4 リリース後の実環境テストが必要。macOS (WKWebView) は別レンダリングのため install.sh のみ修正 (install-macos.sh は対象外)。

Closes #209