### PR TITLE
release: v0.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-config"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "muhenkan-switch-core"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 license = "LGPL-3.0-only"
 repository = "https://github.com/kimushun1101/muhenkan-switch"

--- a/muhenkan-switch/tauri.conf.json
+++ b/muhenkan-switch/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "muhenkan-switch",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "identifier": "com.muhenkan-switch",
   "build": {
     "frontendDist": "./frontend/dist"


### PR DESCRIPTION
## Summary

v0.11.3 → v0.11.4 パッチリリース。

## v0.11.3 → v0.11.4 変更点

- **#210** (Closes #209): auto-update 経由の GUI 再起動が真っ白になる + spawn ターミナルが早期クローズする問題を修正
  - install.sh: GUI 起動を `setsid` で新セッション完全 detach に変更
  - spawn_update_terminal: ターミナル末尾の `read` を `read _ </dev/tty` に変更

## Release flow

このマージ後、main に `v0.11.4` タグを push → CI が release を作る。

検証: v0.11.3 GUI が v0.11.4 を検出 → auto-update → ターミナルが Enter まで開いたまま + 再起動 GUI が真っ白にならない。