### PR TITLE
chore(deps): Rust 1.98 に更新

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@
 #   mise run gen-ts      Rust の Config 系 type から frontend/src/lib/config.ts を生成 (build 依存に組込済)
 
 [tools]
-rust = "1.96"
+rust = "1.98"
 node = "lts"
 
 [tasks.setup]


### PR DESCRIPTION
## Summary
- `mise.toml` の rust ツールチェーンを 1.96 → 1.98 に更新
- 1.97.0 / 1.98.0 のリリースノートを確認し、本 workspace に影響する破壊的変更がないことを確認済み
  - 1.97: シンボルマングリング v0 既定化・リンカ出力の可視化 → いずれもビルド結果やCIの `-D warnings`（clippy 限定）には無関係
  - 1.98: 破壊的変更なし
- CI (`ci.yml` / `release.yml`) は `dtolnay/rust-toolchain@stable` を使用しており `mise.toml` の pin とは独立に常に最新安定版でビルドされる。今回の変更はローカル開発環境の pin を追従させるもの

## Test plan
- [x] `cargo test --workspace` (rust 1.98.1) — 96 tests passed (19 + 43 + 34)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (rust 1.98.1) — warnings なし
- [x] `cargo fmt --all -- --check` — 差分なし

Closes #254

https://claude.ai/code/session_01SnRpk8MtFE9QXcXGpxcHVW